### PR TITLE
fix: add timeout to warp stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ utoipa-swagger-ui = { version = "9.0.0", features = ["actix-web", "reqwest"] }
 uuid = { version = "1.15.1", features = ["v4", "serde"] }
 walkdir = "2.5.0"
 webp = "0.3.0"
+tokio = "1.44.0"

--- a/src/update/warps_stats.rs
+++ b/src/update/warps_stats.rs
@@ -7,6 +7,7 @@ use std::{
 use actix_web::rt;
 use anyhow::Result;
 use sqlx::PgPool;
+use tokio::time::timeout;
 
 use crate::database;
 
@@ -23,20 +24,36 @@ pub async fn spawn(pool: PgPool) {
 
             let start = Instant::now();
 
-            if let Err(e) = update(pool.clone()).await {
-                error!(
-                    "Warps stats update failed with {e} in {}s",
-                    start.elapsed().as_secs_f64()
-                );
+            // Set a 10-minute timeout for the update task
+            match timeout(Duration::from_secs(10 * 60), update(pool.clone())).await {
+                Ok(result) => {
+                    match result {
+                        Ok(_) => {
+                            info!(
+                                "Warps stats update succeeded in {}s",
+                                start.elapsed().as_secs_f64()
+                            );
 
-                success = false;
-            } else {
-                info!(
-                    "Warps stats update succeeded in {}s",
-                    start.elapsed().as_secs_f64()
-                );
+                            success = true;
+                        }
+                        Err(e) => {
+                            error!(
+                                "Warps stats update failed with {e} in {}s",
+                                start.elapsed().as_secs_f64()
+                            );
 
-                success = true;
+                            success = false;
+                        }
+                    }
+                }
+                Err(_) => {
+                    error!(
+                        "Warps stats update timed out after {}s",
+                        start.elapsed().as_secs_f64()
+                    );
+
+                    success = false;
+                }
             }
         }
     });

--- a/src/update/wishes_stats.rs
+++ b/src/update/wishes_stats.rs
@@ -7,6 +7,7 @@ use std::{
 use actix_web::rt;
 use anyhow::Result;
 use sqlx::PgPool;
+use tokio::time::timeout;
 
 use crate::database;
 
@@ -23,20 +24,36 @@ pub async fn spawn(pool: PgPool) {
 
             let start = Instant::now();
 
-            if let Err(e) = update(pool.clone()).await {
-                error!(
-                    "Wishes stats update failed with {e} in {}s",
-                    start.elapsed().as_secs_f64()
-                );
+            // Set a 10-minute timeout for the update task
+            match timeout(Duration::from_secs(10 * 60), update(pool.clone())).await {
+                Ok(result) => {
+                    match result {
+                        Ok(_) => {
+                            info!(
+                                "Wishes stats update succeeded in {}s",
+                                start.elapsed().as_secs_f64()
+                            );
 
-                success = false;
-            } else {
-                info!(
-                    "Wishes stats update succeeded in {}s",
-                    start.elapsed().as_secs_f64()
-                );
+                            success = true;
+                        }
+                        Err(e) => {
+                            error!(
+                                "Wishes stats update failed with {e} in {}s",
+                                start.elapsed().as_secs_f64()
+                            );
 
-                success = true;
+                            success = false;
+                        }
+                    }
+                }
+                Err(_) => {
+                    error!(
+                        "Wishes stats update timed out after {}s",
+                        start.elapsed().as_secs_f64()
+                    );
+
+                    success = false;
+                }
             }
         }
     });


### PR DESCRIPTION
Adds 10 minute timeout to warp/wish/signal stats.
Don't know if it works as I can't easily test it locally, it compiles though.