### PR TITLE
Add NTE roll/pull tracker API and marker screenshot URLs

### DIFF
--- a/migrations/20260616000000_ntehelper_tracker.sql
+++ b/migrations/20260616000000_ntehelper_tracker.sql
@@ -1,0 +1,61 @@
+CREATE TABLE ntehelper_tracker_uid_claim (
+    uid bigint PRIMARY KEY,
+    owner_user_id bigint NOT NULL,
+    claim_source text NOT NULL,
+    claimed_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT ntehelper_tracker_uid_claim_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT ntehelper_tracker_uid_claim_uid_check CHECK (uid BETWEEN 100000 AND 999999999999),
+    CONSTRAINT ntehelper_tracker_uid_claim_source_check CHECK (claim_source IN ('self', 'admin'))
+);
+
+CREATE UNIQUE INDEX ntehelper_tracker_uid_claim_self_owner_idx
+    ON ntehelper_tracker_uid_claim (owner_user_id)
+    WHERE claim_source = 'self';
+
+CREATE INDEX ntehelper_tracker_uid_claim_owner_idx
+    ON ntehelper_tracker_uid_claim (owner_user_id, claimed_at DESC);
+
+CREATE TABLE ntehelper_tracker_pull (
+    uid bigint NOT NULL,
+    record_uid text NOT NULL,
+    pool_group_id text NOT NULL,
+    banner_type text NOT NULL,
+    timestamp_raw text NOT NULL,
+    timestamp_group_ordinal integer,
+    roll_result integer,
+    result_type text,
+    reward_type text NOT NULL,
+    reward_id text NOT NULL,
+    reward_name text NOT NULL,
+    reward_rank text,
+    star_rank integer,
+    quantity integer,
+    imported_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (uid, record_uid),
+    CONSTRAINT ntehelper_tracker_pull_uid_fkey FOREIGN KEY (uid) REFERENCES ntehelper_tracker_uid_claim (uid) ON DELETE CASCADE,
+    CONSTRAINT ntehelper_tracker_pull_record_uid_check CHECK (
+        char_length(btrim(record_uid)) BETWEEN 1 AND 128
+        AND btrim(record_uid) !~ '[^A-Za-z0-9_.:-]'
+    ),
+    CONSTRAINT ntehelper_tracker_pull_pool_group_check CHECK (pool_group_id IN ('Lottery_LimitedCharacter', 'Lottery_Permanent', 'Arc_MiracleBox')),
+    CONSTRAINT ntehelper_tracker_pull_banner_type_check CHECK (banner_type IN ('limited-character', 'permanent-character', 'arc')),
+    CONSTRAINT ntehelper_tracker_pull_timestamp_raw_check CHECK (timestamp_raw ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'),
+    CONSTRAINT ntehelper_tracker_pull_timestamp_group_ordinal_check CHECK (timestamp_group_ordinal IS NULL OR timestamp_group_ordinal >= 0),
+    CONSTRAINT ntehelper_tracker_pull_roll_result_check CHECK (roll_result IS NULL OR roll_result >= 0),
+    CONSTRAINT ntehelper_tracker_pull_result_type_check CHECK (result_type IS NULL OR char_length(btrim(result_type)) BETWEEN 1 AND 64),
+    CONSTRAINT ntehelper_tracker_pull_reward_type_check CHECK (char_length(btrim(reward_type)) BETWEEN 1 AND 64),
+    CONSTRAINT ntehelper_tracker_pull_reward_id_check CHECK (char_length(btrim(reward_id)) BETWEEN 1 AND 128),
+    CONSTRAINT ntehelper_tracker_pull_reward_name_check CHECK (char_length(btrim(reward_name)) BETWEEN 1 AND 128),
+    CONSTRAINT ntehelper_tracker_pull_reward_rank_check CHECK (reward_rank IS NULL OR reward_rank IN ('S', 'A', 'B')),
+    CONSTRAINT ntehelper_tracker_pull_star_rank_check CHECK (star_rank IS NULL OR star_rank IN (3, 4, 5)),
+    CONSTRAINT ntehelper_tracker_pull_quantity_check CHECK (quantity IS NULL OR quantity >= 0)
+);
+
+CREATE INDEX ntehelper_tracker_pull_uid_timestamp_idx
+    ON ntehelper_tracker_pull (uid, timestamp_raw DESC);
+
+CREATE INDEX ntehelper_tracker_pull_uid_banner_timestamp_idx
+    ON ntehelper_tracker_pull (uid, banner_type, timestamp_raw DESC);
+
+

--- a/migrations/20260616000000_ntehelper_tracker.sql
+++ b/migrations/20260616000000_ntehelper_tracker.sql
@@ -38,8 +38,6 @@ CREATE TABLE ntehelper_tracker_pull (
         char_length(btrim(record_uid)) BETWEEN 1 AND 128
         AND btrim(record_uid) !~ '[^A-Za-z0-9_.:-]'
     ),
-    CONSTRAINT ntehelper_tracker_pull_pool_group_check CHECK (pool_group_id IN ('Lottery_LimitedCharacter', 'Lottery_Permanent', 'Arc_MiracleBox')),
-    CONSTRAINT ntehelper_tracker_pull_banner_type_check CHECK (banner_type IN ('limited-character', 'permanent-character', 'arc')),
     CONSTRAINT ntehelper_tracker_pull_timestamp_raw_check CHECK (timestamp_raw ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'),
     CONSTRAINT ntehelper_tracker_pull_timestamp_group_ordinal_check CHECK (timestamp_group_ordinal IS NULL OR timestamp_group_ordinal >= 0),
     CONSTRAINT ntehelper_tracker_pull_roll_result_check CHECK (roll_result IS NULL OR roll_result >= 0),
@@ -47,7 +45,6 @@ CREATE TABLE ntehelper_tracker_pull (
     CONSTRAINT ntehelper_tracker_pull_reward_type_check CHECK (char_length(btrim(reward_type)) BETWEEN 1 AND 64),
     CONSTRAINT ntehelper_tracker_pull_reward_id_check CHECK (char_length(btrim(reward_id)) BETWEEN 1 AND 128),
     CONSTRAINT ntehelper_tracker_pull_reward_name_check CHECK (char_length(btrim(reward_name)) BETWEEN 1 AND 128),
-    CONSTRAINT ntehelper_tracker_pull_reward_rank_check CHECK (reward_rank IS NULL OR reward_rank IN ('S', 'A', 'B')),
     CONSTRAINT ntehelper_tracker_pull_star_rank_check CHECK (star_rank IS NULL OR star_rank IN (3, 4, 5)),
     CONSTRAINT ntehelper_tracker_pull_quantity_check CHECK (quantity IS NULL OR quantity >= 0)
 );

--- a/migrations/20260616010000_ntehelper_tracker_claim_detach.sql
+++ b/migrations/20260616010000_ntehelper_tracker_claim_detach.sql
@@ -1,0 +1,15 @@
+ALTER TABLE ntehelper_tracker_uid_claim
+    DROP CONSTRAINT ntehelper_tracker_uid_claim_owner_user_id_fkey;
+
+ALTER TABLE ntehelper_tracker_uid_claim
+    ALTER COLUMN owner_user_id DROP NOT NULL;
+
+ALTER TABLE ntehelper_tracker_uid_claim
+    ADD CONSTRAINT ntehelper_tracker_uid_claim_owner_user_id_fkey
+    FOREIGN KEY (owner_user_id) REFERENCES users (id) ON DELETE SET NULL;
+
+DROP INDEX ntehelper_tracker_uid_claim_self_owner_idx;
+
+CREATE INDEX ntehelper_tracker_uid_claim_self_owner_idx
+    ON ntehelper_tracker_uid_claim (owner_user_id)
+    WHERE claim_source = 'self';

--- a/migrations/20260617000000_ntehelper_tracker_nickname.sql
+++ b/migrations/20260617000000_ntehelper_tracker_nickname.sql
@@ -1,0 +1,8 @@
+ALTER TABLE ntehelper_tracker_uid_claim
+    ADD COLUMN nickname text NOT NULL DEFAULT '';
+
+ALTER TABLE ntehelper_tracker_uid_claim
+    ADD CONSTRAINT ntehelper_tracker_uid_claim_nickname_check CHECK (
+        char_length(btrim(nickname)) <= 24
+        AND btrim(nickname) !~ '[[:cntrl:]]'
+    );

--- a/migrations/20260623010000_ntehelper_marker_comment_screenshot_urls.sql
+++ b/migrations/20260623010000_ntehelper_marker_comment_screenshot_urls.sql
@@ -1,0 +1,8 @@
+ALTER TABLE ntehelper_marker_comment
+    ADD COLUMN screenshot_urls jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE ntehelper_marker_comment
+    ADD CONSTRAINT ntehelper_marker_comment_screenshot_urls_check CHECK (
+        jsonb_typeof(screenshot_urls) = 'array'
+        AND jsonb_array_length(screenshot_urls) <= 4
+    );

--- a/migrations/20260625000000_ntehelper_tracker_relax_enum_checks.sql
+++ b/migrations/20260625000000_ntehelper_tracker_relax_enum_checks.sql
@@ -1,4 +1,0 @@
-ALTER TABLE ntehelper_tracker_pull
-    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_pool_group_check,
-    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_banner_type_check,
-    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_reward_rank_check;

--- a/migrations/20260625000000_ntehelper_tracker_relax_enum_checks.sql
+++ b/migrations/20260625000000_ntehelper_tracker_relax_enum_checks.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ntehelper_tracker_pull
+    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_pool_group_check,
+    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_banner_type_check,
+    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_reward_rank_check;

--- a/src/api/ntehelper/mod.rs
+++ b/src/api/ntehelper/mod.rs
@@ -1,3 +1,5 @@
+mod tracker;
+
 use actix_session::Session;
 use actix_web::{delete, get, patch, post, put, web, HttpRequest, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
@@ -27,6 +29,8 @@ const DEFAULT_MARKER_COMMENT_LIMIT: i64 = 10;
 const MAX_MARKER_COMMENT_LIMIT: i64 = 50;
 const MAX_MARKER_COMMENT_BODY_CHARS: usize = 250;
 const MARKER_COMMENT_CREATE_LIMIT_PER_WINDOW: i64 = 60;
+const MAX_MARKER_COMMENT_SCREENSHOT_URLS: usize = 4;
+const MAX_MARKER_COMMENT_SCREENSHOT_URL_CHARS: usize = 2048;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -64,7 +68,9 @@ const MARKER_COMMENT_CREATE_LIMIT_PER_WINDOW: i64 = 60;
 struct ApiDoc;
 
 pub fn openapi() -> utoipa::openapi::OpenApi {
-    ApiDoc::openapi()
+    let mut openapi = ApiDoc::openapi();
+    openapi.merge(tracker::openapi());
+    openapi
 }
 
 pub fn configure(cfg: &mut web::ServiceConfig) {
@@ -78,7 +84,8 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(post_marker_comment)
         .service(patch_marker_comment)
         .service(delete_marker_comment)
-        .service(put_marker_comment_vote);
+        .service(put_marker_comment_vote)
+        .configure(tracker::configure);
 }
 
 #[derive(Serialize, ToSchema)]
@@ -167,6 +174,8 @@ struct MarkerCommentResponse {
     marker_key: String,
     username: String,
     body: String,
+    #[serde(rename = "screenshotUrls")]
+    screenshot_urls: Vec<String>,
     #[serde(rename = "createdAt")]
     created_at: chrono::DateTime<chrono::Utc>,
     #[serde(rename = "updatedAt")]
@@ -185,11 +194,15 @@ struct MarkerCommentCreateRequest {
     #[serde(rename = "markerKey")]
     marker_key: String,
     body: String,
+    #[serde(rename = "screenshotUrls", default)]
+    screenshot_urls: Vec<String>,
 }
 
 #[derive(Deserialize, ToSchema)]
 struct MarkerCommentUpdateRequest {
     body: String,
+    #[serde(rename = "screenshotUrls", default)]
+    screenshot_urls: Vec<String>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -474,6 +487,9 @@ async fn post_marker_comment(
     };
 
     let body = data.body.trim();
+    let Some(screenshot_urls) = valid_marker_comment_screenshot_urls(&data.screenshot_urls) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid screenshot URLs"));
+    };
     if !valid_marker_key(&data.marker_key) || !valid_marker_comment_body(body) {
         return Ok(HttpResponse::BadRequest().finish());
     }
@@ -490,9 +506,19 @@ async fn post_marker_comment(
             .finish());
     }
 
-    let comment =
-        database::ntehelper::create_marker_comment(&username, &data.marker_key, body, &pool)
-            .await?;
+    let comment = database::ntehelper::create_marker_comment(
+        &username,
+        &data.marker_key,
+        body,
+        &Value::Array(
+            screenshot_urls
+                .into_iter()
+                .map(Value::String)
+                .collect(),
+        ),
+        &pool,
+    )
+    .await?;
 
     Ok(HttpResponse::Ok().json(MarkerCommentResponse::from(comment)))
 }
@@ -521,13 +547,26 @@ async fn patch_marker_comment(
     };
 
     let body = data.body.trim();
+    let Some(screenshot_urls) = valid_marker_comment_screenshot_urls(&data.screenshot_urls) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid screenshot URLs"));
+    };
     if !valid_marker_comment_body(body) {
         return Ok(HttpResponse::BadRequest().finish());
     }
 
-    let Some(comment) =
-        database::ntehelper::update_marker_comment(comment_id.into_inner(), &username, body, &pool)
-            .await?
+    let Some(comment) = database::ntehelper::update_marker_comment(
+        comment_id.into_inner(),
+        &username,
+        body,
+        &Value::Array(
+            screenshot_urls
+                .into_iter()
+                .map(Value::String)
+                .collect(),
+        ),
+        &pool,
+    )
+    .await?
     else {
         return Ok(HttpResponse::Forbidden().finish());
     };
@@ -639,6 +678,38 @@ fn valid_marker_comment_body(body: &str) -> bool {
     char_count >= 1 && char_count <= MAX_MARKER_COMMENT_BODY_CHARS
 }
 
+fn valid_marker_comment_screenshot_urls(urls: &[String]) -> Option<Vec<String>> {
+    if urls.len() > MAX_MARKER_COMMENT_SCREENSHOT_URLS {
+        return None;
+    }
+
+    let mut normalized = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for url in urls {
+        let trimmed = url.trim();
+        if trimmed.is_empty() || trimmed.chars().count() > MAX_MARKER_COMMENT_SCREENSHOT_URL_CHARS {
+            return None;
+        }
+
+        let parsed = url::Url::parse(trimmed).ok()?;
+        let extension = parsed.path().rsplit('.').next()?.to_ascii_lowercase();
+        if !matches!(parsed.scheme(), "http" | "https")
+            || !matches!(extension.as_str(), "png" | "jpg" | "jpeg" | "webp" | "gif" | "avif")
+        {
+            return None;
+        }
+
+        let value = parsed.to_string();
+        if !seen.insert(value.clone()) {
+            continue;
+        }
+        normalized.push(value);
+    }
+
+    Some(normalized)
+}
+
 fn valid_setting_namespace(namespace: &str) -> bool {
     SETTING_NAMESPACES.contains(&namespace)
 }
@@ -650,7 +721,7 @@ fn valid_setting_value(data: &Value) -> bool {
             .unwrap_or(false)
 }
 
-fn valid_nte_origin(request: &HttpRequest) -> bool {
+pub(super) fn valid_nte_origin(request: &HttpRequest) -> bool {
     let Some(origin) = request.headers().get("Origin") else {
         return true;
     };
@@ -820,6 +891,13 @@ impl From<database::ntehelper::DbMarkerComment> for MarkerCommentResponse {
             marker_key: comment.marker_key,
             username: comment.username,
             body: comment.body,
+            screenshot_urls: comment
+                .screenshot_urls
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect(),
             created_at: comment.created_at,
             updated_at: comment.updated_at,
             score: comment.score,

--- a/src/api/ntehelper/mod.rs
+++ b/src/api/ntehelper/mod.rs
@@ -2,8 +2,11 @@ mod tracker;
 
 use actix_session::Session;
 use actix_web::{delete, get, patch, post, put, web, HttpRequest, HttpResponse, Responder};
+use reqwest::header;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::ToSocketAddrs;
+use std::time::Duration;
 
 use serde_json::{json, Value};
 use sqlx::PgPool;
@@ -31,6 +34,7 @@ const MAX_MARKER_COMMENT_BODY_CHARS: usize = 250;
 const MARKER_COMMENT_CREATE_LIMIT_PER_WINDOW: i64 = 60;
 const MAX_MARKER_COMMENT_SCREENSHOT_URLS: usize = 4;
 const MAX_MARKER_COMMENT_SCREENSHOT_URL_CHARS: usize = 2048;
+const MARKER_COMMENT_SCREENSHOT_VALIDATE_TIMEOUT_SECS: u64 = 8;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -487,7 +491,11 @@ async fn post_marker_comment(
     };
 
     let body = data.body.trim();
-    let Some(screenshot_urls) = valid_marker_comment_screenshot_urls(&data.screenshot_urls) else {
+    let Some(screenshot_urls) = normalize_marker_comment_screenshot_urls(&data.screenshot_urls)
+    else {
+        return Ok(HttpResponse::BadRequest().body("Invalid screenshot URLs"));
+    };
+    if !validate_marker_comment_screenshot_urls(&screenshot_urls).await {
         return Ok(HttpResponse::BadRequest().body("Invalid screenshot URLs"));
     };
     if !valid_marker_key(&data.marker_key) || !valid_marker_comment_body(body) {
@@ -547,7 +555,11 @@ async fn patch_marker_comment(
     };
 
     let body = data.body.trim();
-    let Some(screenshot_urls) = valid_marker_comment_screenshot_urls(&data.screenshot_urls) else {
+    let Some(screenshot_urls) = normalize_marker_comment_screenshot_urls(&data.screenshot_urls)
+    else {
+        return Ok(HttpResponse::BadRequest().body("Invalid screenshot URLs"));
+    };
+    if !validate_marker_comment_screenshot_urls(&screenshot_urls).await {
         return Ok(HttpResponse::BadRequest().body("Invalid screenshot URLs"));
     };
     if !valid_marker_comment_body(body) {
@@ -678,7 +690,7 @@ fn valid_marker_comment_body(body: &str) -> bool {
     char_count >= 1 && char_count <= MAX_MARKER_COMMENT_BODY_CHARS
 }
 
-fn valid_marker_comment_screenshot_urls(urls: &[String]) -> Option<Vec<String>> {
+fn normalize_marker_comment_screenshot_urls(urls: &[String]) -> Option<Vec<String>> {
     if urls.len() > MAX_MARKER_COMMENT_SCREENSHOT_URLS {
         return None;
     }
@@ -708,6 +720,167 @@ fn valid_marker_comment_screenshot_urls(urls: &[String]) -> Option<Vec<String>> 
     }
 
     Some(normalized)
+}
+
+async fn validate_marker_comment_screenshot_urls(urls: &[String]) -> bool {
+    if urls.is_empty() {
+        return true;
+    }
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(
+            MARKER_COMMENT_SCREENSHOT_VALIDATE_TIMEOUT_SECS,
+        ))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+
+    for url in urls {
+        if !validate_marker_comment_screenshot_url(&client, url).await {
+            return false;
+        }
+    }
+
+    true
+}
+
+async fn validate_marker_comment_screenshot_url(client: &reqwest::Client, url: &str) -> bool {
+    let mut current = match url::Url::parse(url) {
+        Ok(url) => url,
+        Err(_) => return false,
+    };
+
+    for _ in 0..=3 {
+        if !url_targets_public_host(&current) {
+            return false;
+        }
+
+        let head = match client.head(current.clone()).send().await {
+            Ok(response) => response,
+            Err(_) => return false,
+        };
+
+        if let Some(next) = redirect_target(&current, &head) {
+            current = next;
+            continue;
+        }
+        if response_has_image_content_type(&head) {
+            return true;
+        }
+
+        let get = match client
+            .get(current.clone())
+            .header(header::RANGE, "bytes=0-0")
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(_) => return false,
+        };
+
+        if let Some(next) = redirect_target(&current, &get) {
+            current = next;
+            continue;
+        }
+
+        return response_has_image_content_type(&get);
+    }
+
+    false
+}
+
+fn redirect_target(current: &url::Url, response: &reqwest::Response) -> Option<url::Url> {
+    if !response.status().is_redirection() {
+        return None;
+    }
+
+    let location = response.headers().get(header::LOCATION)?.to_str().ok()?;
+    current.join(location).ok()
+}
+
+fn response_has_image_content_type(response: &reqwest::Response) -> bool {
+    if !response.status().is_success() {
+        return false;
+    }
+
+    response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .is_some_and(|value| value.starts_with("image/"))
+}
+
+fn url_targets_public_host(url: &url::Url) -> bool {
+    if !url.username().is_empty() || url.password().is_some() {
+        return false;
+    }
+
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let normalized_host = host.trim_start_matches('[').trim_end_matches(']');
+    if !valid_public_hostname(normalized_host) {
+        return false;
+    }
+
+    let port = url.port_or_known_default().unwrap_or(80);
+    let Ok(addresses) = (normalized_host, port).to_socket_addrs() else {
+        return false;
+    };
+
+    let mut resolved_any = false;
+    for address in addresses {
+        resolved_any = true;
+        if !is_public_ip(address.ip()) {
+            return false;
+        }
+    }
+
+    resolved_any
+}
+
+fn valid_public_hostname(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost")
+        || host.eq_ignore_ascii_case("localhost.localdomain")
+        || host.ends_with(".local")
+        || host.ends_with(".internal")
+    {
+        return false;
+    }
+
+    true
+}
+
+fn is_public_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(ip) => {
+            let [a, b, ..] = ip.octets();
+            !ip.is_private()
+                && !ip.is_loopback()
+                && !ip.is_link_local()
+                && !ip.is_broadcast()
+                && !ip.is_documentation()
+                && !ip.is_unspecified()
+                && !ip.is_multicast()
+                && !(a == 100 && (64..=127).contains(&b))
+                && !(a == 198 && matches!(b, 18 | 19))
+                && !(a >= 240)
+        }
+        std::net::IpAddr::V6(ip) => {
+            let segments = ip.segments();
+            !ip.is_loopback()
+                && !ip.is_unspecified()
+                && !ip.is_multicast()
+                && !ip.is_unique_local()
+                && !ip.is_unicast_link_local()
+                && !(segments[0] == 0x2001 && segments[1] == 0x0db8)
+        }
+    }
 }
 
 fn valid_setting_namespace(namespace: &str) -> bool {
@@ -913,7 +1086,9 @@ impl From<database::ntehelper::DbMarkerComment> for MarkerCommentResponse {
 mod tests {
     use super::valid_nte_origin;
     use super::valid_nte_origin_value;
+    use super::{is_public_ip, valid_public_hostname};
     use actix_web::test::TestRequest;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn accepts_public_nte_origin() {
@@ -946,5 +1121,28 @@ mod tests {
         assert!(!valid_nte_origin_value("https://stardb.gg"));
         assert!(!valid_nte_origin_value("https://example.com"));
         assert!(!valid_nte_origin_value("ftp://localhost"));
+    }
+
+    #[test]
+    fn rejects_local_or_internal_marker_screenshot_hosts() {
+        assert!(!valid_public_hostname("localhost"));
+        assert!(!valid_public_hostname("printer.local"));
+        assert!(!valid_public_hostname("api.internal"));
+        assert!(valid_public_hostname("i.imgur.com"));
+    }
+
+    #[test]
+    fn rejects_non_public_marker_screenshot_ips() {
+        assert!(!is_public_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(!is_public_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(!is_public_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))));
+        assert!(!is_public_ip(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+        assert!(!is_public_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))));
+        assert!(!is_public_ip(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
+        assert!(!is_public_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(!is_public_ip(IpAddr::V6(Ipv6Addr::UNSPECIFIED)));
+        assert!(!is_public_ip(IpAddr::V6(
+            "fc00::1".parse().expect("valid unique-local IPv6 address"),
+        )));
     }
 }

--- a/src/api/ntehelper/tracker.rs
+++ b/src/api/ntehelper/tracker.rs
@@ -1,0 +1,956 @@
+use actix_session::Session;
+use actix_web::{
+    delete, get, http::StatusCode, post, put, web, HttpRequest, HttpResponse, Responder,
+};
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::collections::HashMap;
+use utoipa::{OpenApi, ToSchema};
+
+use crate::{api::ApiResult, database};
+
+const TRACKER_UID_LEN: usize = 12;
+const TRACKER_UID_PREFIX: &str = "21";
+const TRACKER_IMPORT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+const TRACKER_IMPORT_MAX_EXPORTS: usize = 10;
+const TRACKER_IMPORT_MAX_RECORDS: usize = 10_000;
+const TRACKER_MAX_STORED_RECORDS: i64 = 100_000;
+const TRACKER_MAX_SELF_CLAIMS: i64 = 3;
+const TRACKER_RECORD_UID_MAX_CHARS: usize = 128;
+const TRACKER_TEXT_MAX_CHARS: usize = 64;
+const TRACKER_REWARD_TEXT_MAX_CHARS: usize = 128;
+const TRACKER_NICKNAME_MAX_CHARS: usize = 24;
+
+#[derive(OpenApi)]
+#[openapi(
+    tags((name = "ntehelper/tracker")),
+    paths(
+        get_tracker_uids_me,
+        post_tracker_uid_claim,
+        put_tracker_uid_claim,
+        delete_tracker_uid_claim,
+        get_tracker_uid,
+        post_tracker_import,
+        delete_tracker_pulls,
+    ),
+    components(schemas(
+        TrackerClaimRequest,
+        TrackerClaimUpdateRequest,
+        TrackerClaimsResponse,
+        TrackerImportRequest,
+        TrackerImportResponse,
+        TrackerPullResponse,
+        TrackerUidClaimResponse,
+        TrackerUidDeleteResponse,
+        TrackerUidPageResponse,
+    ))
+)]
+struct ApiDoc;
+
+pub fn openapi() -> utoipa::openapi::OpenApi {
+    ApiDoc::openapi()
+}
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_tracker_uids_me)
+        .service(post_tracker_uid_claim)
+        .service(put_tracker_uid_claim)
+        .service(delete_tracker_uid_claim)
+        .service(get_tracker_uid)
+        .service(post_tracker_import)
+        .service(delete_tracker_pulls);
+}
+
+#[derive(Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerClaimRequest {
+    uid: String,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerClaimsResponse {
+    claims: Vec<TrackerUidClaimResponse>,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerUidClaimResponse {
+    uid: String,
+    nickname: String,
+    owner_username: Option<String>,
+    claim_source: String,
+    has_profile: bool,
+    claimed_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerClaimUpdateRequest {
+    nickname: String,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerUidPageResponse {
+    claim: Option<TrackerUidClaimResponse>,
+    pulls: Vec<TrackerPullResponse>,
+    viewer_can_manage: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerUidDeleteResponse {
+    deleted_pulls: i64,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerPullResponse {
+    uid: String,
+    record_uid: String,
+    pool_group_id: String,
+    banner_type: String,
+    timestamp_raw: String,
+    timestamp_group_ordinal: i32,
+    reward_type: String,
+    reward_id: String,
+    reward_name: String,
+    reward_rank: Option<String>,
+    star_rank: Option<i32>,
+    roll_result: Option<i32>,
+    result_type: Option<String>,
+    quantity: Option<i32>,
+    source_type: Option<String>,
+    imported_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerImportRequest {
+    exports: Vec<RawTrackerExport>,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TrackerImportResponse {
+    uid: String,
+    received: usize,
+    imported: i64,
+    skipped_duplicate: i64,
+    inserted: i64,
+    duplicates: i64,
+    total: i64,
+}
+
+#[derive(Deserialize, ToSchema)]
+struct RawTrackerExport {
+    format: String,
+    #[serde(rename = "format_version")]
+    format_version: i32,
+    user_uid: String,
+    banner: RawTrackerBanner,
+    records: Vec<RawTrackerRecord>,
+}
+
+#[derive(Deserialize, ToSchema)]
+struct RawTrackerBanner {
+    id: String,
+}
+
+#[derive(Deserialize, ToSchema)]
+struct RawTrackerRecord {
+    uid: String,
+    pool_group_id: String,
+    timestamp: String,
+    timestamp_group_ordinal: i32,
+    roll_result: Option<i32>,
+    result_type: Option<String>,
+    reward_type: String,
+    reward_id: String,
+    reward_name: String,
+    reward_rank: Option<String>,
+    quantity: Option<i32>,
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    get,
+    path = "/api/ntehelper/tracker/uids/me",
+    responses(
+        (status = 200, description = "Current user's claimed NTE tracker UIDs", body = TrackerClaimsResponse),
+        (status = 400, description = "Not logged in"),
+        (status = 403, description = "Invalid origin"),
+    )
+)]
+#[get("/api/ntehelper/tracker/uids/me")]
+async fn get_tracker_uids_me(
+    request: HttpRequest,
+    session: Session,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    if !super::valid_nte_origin(&request) {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let Some(username) = current_username(&session) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+    let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
+    let claims = database::ntehelper_tracker::tracker_claims_for_user(user_id, &pool)
+        .await?
+        .into_iter()
+        .map(TrackerUidClaimResponse::from)
+        .collect();
+
+    Ok(HttpResponse::Ok().json(TrackerClaimsResponse { claims }))
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    post,
+    path = "/api/ntehelper/tracker/uids/claim",
+    request_body = TrackerClaimRequest,
+    responses(
+        (status = 200, description = "Claimed tracker UID", body = TrackerUidClaimResponse),
+        (status = 400, description = "Not logged in or invalid UID"),
+        (status = 403, description = "Invalid origin"),
+        (status = 409, description = "UID already claimed or self-claim limit reached"),
+    )
+)]
+#[post("/api/ntehelper/tracker/uids/claim")]
+async fn post_tracker_uid_claim(
+    request: HttpRequest,
+    session: Session,
+    body: web::Json<TrackerClaimRequest>,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    if !super::valid_nte_origin(&request) {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let Some(username) = current_username(&session) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+    let Some(uid) = validate_tracker_uid(&body.uid) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid tracker UID"));
+    };
+
+    let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
+    let claim = match database::ntehelper_tracker::claim_tracker_uid(
+        user_id,
+        uid,
+        TRACKER_MAX_SELF_CLAIMS,
+        &pool,
+    )
+            .await?
+        {
+            Ok(claim) => claim,
+            Err(error) => return Ok(HttpResponse::Conflict().body(error.to_string())),
+        };
+
+    Ok(HttpResponse::Ok().json(TrackerUidClaimResponse::from(claim)))
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    put,
+    path = "/api/ntehelper/tracker/uids/{uid}",
+    request_body = TrackerClaimUpdateRequest,
+    responses(
+        (status = 200, description = "Updated claimed tracker UID nickname", body = TrackerUidClaimResponse),
+        (status = 400, description = "Not logged in or invalid UID"),
+        (status = 403, description = "Invalid origin"),
+        (status = 409, description = "UID cannot be updated for this account"),
+    )
+)]
+#[put("/api/ntehelper/tracker/uids/{uid}")]
+async fn put_tracker_uid_claim(
+    request: HttpRequest,
+    session: Session,
+    uid: web::Path<String>,
+    body: web::Json<TrackerClaimUpdateRequest>,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    if !super::valid_nte_origin(&request) {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let Some(username) = current_username(&session) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+    let Some(uid) = validate_tracker_uid(&uid) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid tracker UID"));
+    };
+    let Some(nickname) = validate_tracker_nickname(&body.nickname) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid tracker nickname"));
+    };
+
+    let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
+    let claim = match database::ntehelper_tracker::update_tracker_claim_nickname(
+        user_id,
+        uid,
+        nickname,
+        &pool,
+    )
+            .await?
+        {
+            Ok(claim) => claim,
+            Err(error) => return Ok(HttpResponse::Conflict().body(error.to_string())),
+        };
+
+    Ok(HttpResponse::Ok().json(TrackerUidClaimResponse::from(claim)))
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    delete,
+    path = "/api/ntehelper/tracker/uids/{uid}",
+    responses(
+        (status = 200, description = "Deleted tracker UID claim and stored profile", body = TrackerUidDeleteResponse),
+        (status = 400, description = "Not logged in or invalid UID"),
+        (status = 403, description = "Invalid origin"),
+        (status = 409, description = "UID is not attached to this account"),
+    )
+)]
+#[delete("/api/ntehelper/tracker/uids/{uid}")]
+async fn delete_tracker_uid_claim(
+    request: HttpRequest,
+    session: Session,
+    uid: web::Path<String>,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    if !super::valid_nte_origin(&request) {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let Some(username) = current_username(&session) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+    let Some(uid) = validate_tracker_uid(&uid) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid tracker UID"));
+    };
+
+    let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
+    match database::ntehelper_tracker::delete_tracker_uid_profile(user_id, uid, &pool).await? {
+        Ok(deleted_pulls) => Ok(HttpResponse::Ok().json(TrackerUidDeleteResponse {
+            deleted_pulls,
+        })),
+        Err(error) => Ok(HttpResponse::Conflict().body(error.to_string())),
+    }
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    get,
+    path = "/api/ntehelper/tracker/{uid}",
+    responses((status = 200, description = "Public tracker UID page data", body = TrackerUidPageResponse))
+)]
+#[get("/api/ntehelper/tracker/{uid}")]
+async fn get_tracker_uid(
+    session: Session,
+    uid: web::Path<String>,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    let Some(uid) = validate_tracker_uid(&uid) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+
+    let viewer_user_id = match current_username(&session) {
+        Some(username) => database::ntehelper_tracker::get_tracker_user_id(&username, &pool)
+            .await
+            .ok(),
+        None => None,
+    };
+    let response = tracker_response(uid, viewer_user_id, &pool).await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    post,
+    path = "/api/ntehelper/tracker/{uid}/import",
+    request_body = TrackerImportRequest,
+    responses(
+        (status = 200, description = "Imported tracker pulls", body = TrackerImportResponse),
+        (status = 400, description = "Not logged in or invalid import"),
+        (status = 403, description = "Invalid origin or non-owner"),
+        (status = 404, description = "UID is not claimed"),
+        (status = 413, description = "Import limit reached"),
+    )
+)]
+#[post("/api/ntehelper/tracker/{uid}/import")]
+async fn post_tracker_import(
+    request: HttpRequest,
+    session: Session,
+    uid: web::Path<String>,
+    payload: web::Payload,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    if !super::valid_nte_origin(&request) {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let Some(username) = current_username(&session) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+    let Some(uid) = validate_tracker_uid(&uid) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid tracker UID"));
+    };
+    let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
+
+    match owner_claim(uid, user_id, &pool).await? {
+        OwnerClaim::Missing => return Ok(HttpResponse::NotFound().finish()),
+        OwnerClaim::Forbidden => return Ok(HttpResponse::Forbidden().finish()),
+        OwnerClaim::Allowed => {}
+    }
+
+    let body = match read_import_body(payload).await {
+        Ok(body) => body,
+        Err(response) => return Ok(response),
+    };
+    let (pulls, received) = match normalize_tracker_exports(uid, body) {
+        Ok(normalized) => normalized,
+        Err(error) => return Ok(error.response()),
+    };
+
+    let Some(result) =
+        database::ntehelper_tracker::import_tracker_pulls(
+            uid,
+            &pulls,
+            TRACKER_MAX_STORED_RECORDS,
+            &pool,
+        )
+            .await?
+    else {
+        return Ok(HttpResponse::PayloadTooLarge().body("Tracker UID pull limit reached"));
+    };
+
+    let imported = result.inserted;
+    let skipped_duplicate = received.saturating_sub(imported as usize) as i64;
+
+    Ok(HttpResponse::Ok().json(TrackerImportResponse {
+        uid: uid.to_string(),
+        received,
+        imported,
+        skipped_duplicate,
+        inserted: imported,
+        duplicates: skipped_duplicate,
+        total: result.total,
+    }))
+}
+
+#[utoipa::path(
+    tag = "ntehelper/tracker",
+    delete,
+    path = "/api/ntehelper/tracker/{uid}/pulls",
+    responses(
+        (status = 200, description = "Cleared tracker pulls"),
+        (status = 400, description = "Not logged in or invalid UID"),
+        (status = 403, description = "Invalid origin or non-owner"),
+        (status = 404, description = "UID is not claimed"),
+    )
+)]
+#[delete("/api/ntehelper/tracker/{uid}/pulls")]
+async fn delete_tracker_pulls(
+    request: HttpRequest,
+    session: Session,
+    uid: web::Path<String>,
+    pool: web::Data<PgPool>,
+) -> ApiResult<impl Responder> {
+    if !super::valid_nte_origin(&request) {
+        return Ok(HttpResponse::Forbidden().finish());
+    }
+
+    let Some(username) = current_username(&session) else {
+        return Ok(HttpResponse::BadRequest().finish());
+    };
+    let Some(uid) = validate_tracker_uid(&uid) else {
+        return Ok(HttpResponse::BadRequest().body("Invalid tracker UID"));
+    };
+    let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
+
+    match owner_claim(uid, user_id, &pool).await? {
+        OwnerClaim::Missing => return Ok(HttpResponse::NotFound().finish()),
+        OwnerClaim::Forbidden => return Ok(HttpResponse::Forbidden().finish()),
+        OwnerClaim::Allowed => {}
+    }
+
+    let deleted = database::ntehelper_tracker::clear_tracker_pulls(uid, &pool).await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "deleted": deleted })))
+}
+
+enum OwnerClaim {
+    Allowed,
+    Missing,
+    Forbidden,
+}
+
+async fn owner_claim(uid: i64, user_id: i64, pool: &PgPool) -> ApiResult<OwnerClaim> {
+    let Some(claim) = database::ntehelper_tracker::get_tracker_claim(uid, pool).await? else {
+        return Ok(OwnerClaim::Missing);
+    };
+
+    Ok(if claim.owner_user_id == Some(user_id) {
+        OwnerClaim::Allowed
+    } else if claim.owner_user_id.is_none() {
+        OwnerClaim::Missing
+    } else {
+        OwnerClaim::Forbidden
+    })
+}
+
+async fn tracker_response(
+    uid: i64,
+    viewer_user_id: Option<i64>,
+    pool: &PgPool,
+) -> ApiResult<TrackerUidPageResponse> {
+    let Some(claim) = database::ntehelper_tracker::get_tracker_claim(uid, pool).await? else {
+        return Ok(TrackerUidPageResponse {
+            claim: None,
+            pulls: Vec::new(),
+            viewer_can_manage: false,
+        });
+    };
+    if !claim.has_profile {
+        return Ok(TrackerUidPageResponse {
+            claim: None,
+            pulls: Vec::new(),
+            viewer_can_manage: false,
+        });
+    }
+    let viewer_can_manage = viewer_user_id == claim.owner_user_id;
+    let pulls = database::ntehelper_tracker::tracker_pulls_for_uid(uid, pool)
+        .await?
+        .into_iter()
+        .map(TrackerPullResponse::from)
+        .collect();
+
+    Ok(TrackerUidPageResponse {
+        claim: Some(TrackerUidClaimResponse::from(claim)),
+        pulls,
+        viewer_can_manage,
+    })
+}
+
+fn current_username(session: &Session) -> Option<String> {
+    session.get::<String>("username").ok().flatten()
+}
+
+fn validate_tracker_uid(value: &str) -> Option<i64> {
+    let trimmed = value.trim();
+    if trimmed.len() != TRACKER_UID_LEN
+        || !trimmed.starts_with(TRACKER_UID_PREFIX)
+        || !trimmed.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    trimmed.parse::<i64>().ok()
+}
+
+fn validate_tracker_nickname(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.chars().count() > TRACKER_NICKNAME_MAX_CHARS {
+        return None;
+    }
+    if trimmed.chars().any(char::is_control) {
+        return None;
+    }
+
+    Some(trimmed)
+}
+
+async fn read_import_body(mut payload: web::Payload) -> Result<TrackerImportRequest, HttpResponse> {
+    let mut bytes = web::BytesMut::new();
+
+    while let Some(chunk) = payload.next().await {
+        let chunk = chunk.map_err(|_| HttpResponse::BadRequest().body("Invalid request body"))?;
+        if bytes.len() + chunk.len() > TRACKER_IMPORT_MAX_BODY_BYTES {
+            return Err(HttpResponse::PayloadTooLarge().body("Tracker import body is too large"));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    serde_json::from_slice::<TrackerImportRequest>(&bytes)
+        .map_err(|_| HttpResponse::BadRequest().body("Invalid tracker import JSON"))
+}
+
+fn normalize_tracker_exports(
+    uid: i64,
+    body: TrackerImportRequest,
+) -> Result<(Vec<database::ntehelper_tracker::DbTrackerPull>, usize), TrackerImportError> {
+    if body.exports.is_empty() {
+        return Err(TrackerImportError::bad_request(
+            "Import requires at least one export",
+        ));
+    }
+    if body.exports.len() > TRACKER_IMPORT_MAX_EXPORTS {
+        return Err(TrackerImportError::too_large(
+            "Too many exports in one import",
+        ));
+    }
+
+    let received = body
+        .exports
+        .iter()
+        .map(|export| export.records.len())
+        .sum::<usize>();
+    if received > TRACKER_IMPORT_MAX_RECORDS {
+        return Err(TrackerImportError::too_large(
+            "Too many records in one import",
+        ));
+    }
+
+    let mut records_by_uid = HashMap::new();
+
+    for export in body.exports {
+        if export.format != "nte-history-export" || export.format_version != 1 {
+            return Err(TrackerImportError::bad_request(
+                "Unsupported tracker export format",
+            ));
+        }
+        if validate_tracker_uid(&export.user_uid) != Some(uid) {
+            return Err(TrackerImportError::bad_request(
+                "Import UID does not match target tracker UID",
+            ));
+        }
+
+        let banner_type = banner_type_for_pool(&export.banner.id)
+            .ok_or_else(|| TrackerImportError::bad_request("Unsupported tracker banner"))?;
+
+        for record in export.records {
+            if record.pool_group_id != export.banner.id {
+                return Err(TrackerImportError::bad_request(
+                    "Record pool does not match export banner",
+                ));
+            }
+
+            let record_uid =
+                safe_identifier(&record.uid, TRACKER_RECORD_UID_MAX_CHARS, "record UID")?;
+            let reward_type =
+                safe_text(&record.reward_type, TRACKER_TEXT_MAX_CHARS, "reward type")?;
+            let reward_id = safe_text(
+                &record.reward_id,
+                TRACKER_REWARD_TEXT_MAX_CHARS,
+                "reward ID",
+            )?;
+            let reward_name = safe_display_text(
+                &record.reward_name,
+                TRACKER_REWARD_TEXT_MAX_CHARS,
+                "reward name",
+            )?;
+            let result_type = record
+                .result_type
+                .map(|value| safe_text(&value, TRACKER_TEXT_MAX_CHARS, "result type"))
+                .transpose()?;
+            let reward_rank = record
+                .reward_rank
+                .map(|rank| normalize_rank(&rank))
+                .transpose()?;
+            let star_rank = star_rank_for_reward_rank(reward_rank.as_deref());
+
+            if !valid_timestamp(&record.timestamp) {
+                return Err(TrackerImportError::bad_request("Invalid tracker timestamp"));
+            }
+            if record.timestamp_group_ordinal < 0 {
+                return Err(TrackerImportError::bad_request(
+                    "Invalid timestamp group ordinal",
+                ));
+            }
+            if record.roll_result.is_some_and(|value| value < 0) {
+                return Err(TrackerImportError::bad_request("Invalid roll result"));
+            }
+            if record.quantity.is_some_and(|value| value < 0) {
+                return Err(TrackerImportError::bad_request("Invalid quantity"));
+            }
+
+            records_by_uid.insert(
+                record_uid.clone(),
+                database::ntehelper_tracker::DbTrackerPull {
+                    uid,
+                    record_uid,
+                    pool_group_id: export.banner.id.clone(),
+                    banner_type: banner_type.to_string(),
+                    timestamp_raw: record.timestamp,
+                    timestamp_group_ordinal: Some(record.timestamp_group_ordinal),
+                    roll_result: record.roll_result,
+                    result_type,
+                    reward_type,
+                    reward_id,
+                    reward_name,
+                    reward_rank,
+                    star_rank,
+                    quantity: record.quantity,
+                    imported_at: Utc::now(),
+                },
+            );
+        }
+    }
+
+    Ok((records_by_uid.into_values().collect(), received))
+}
+
+fn banner_type_for_pool(pool_group_id: &str) -> Option<&'static str> {
+    match pool_group_id {
+        "Lottery_LimitedCharacter" => Some("limited-character"),
+        "Lottery_Permanent" => Some("permanent-character"),
+        "Arc_MiracleBox" => Some("arc"),
+        _ => None,
+    }
+}
+
+fn star_rank_for_reward_rank(rank: Option<&str>) -> Option<i32> {
+    match rank {
+        Some("S") => Some(5),
+        Some("A") => Some(4),
+        Some("B") => Some(3),
+        _ => None,
+    }
+}
+
+fn normalize_rank(rank: &str) -> Result<String, TrackerImportError> {
+    match rank.trim() {
+        "S" | "A" | "B" => Ok(rank.trim().to_string()),
+        _ => Err(TrackerImportError::bad_request("Unsupported reward rank")),
+    }
+}
+
+fn safe_identifier(
+    value: &str,
+    max_chars: usize,
+    label: &'static str,
+) -> Result<String, TrackerImportError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > max_chars
+        || !trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return Err(TrackerImportError::bad_request(format!("Invalid {label}")));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn safe_text(
+    value: &str,
+    max_chars: usize,
+    label: &'static str,
+) -> Result<String, TrackerImportError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > max_chars
+        || !trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':'))
+    {
+        return Err(TrackerImportError::bad_request(format!("Invalid {label}")));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn safe_display_text(
+    value: &str,
+    max_chars: usize,
+    label: &'static str,
+) -> Result<String, TrackerImportError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > max_chars
+        || trimmed.chars().any(char::is_control)
+    {
+        return Err(TrackerImportError::bad_request(format!("Invalid {label}")));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn valid_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 19
+        && bytes[0..4].iter().all(u8::is_ascii_digit)
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(u8::is_ascii_digit)
+        && bytes[10] == b' '
+        && bytes[11..13].iter().all(u8::is_ascii_digit)
+        && bytes[13] == b':'
+        && bytes[14..16].iter().all(u8::is_ascii_digit)
+        && bytes[16] == b':'
+        && bytes[17..19].iter().all(u8::is_ascii_digit)
+}
+
+#[derive(Debug)]
+struct TrackerImportError {
+    status: StatusCode,
+    message: String,
+}
+
+impl TrackerImportError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    fn too_large(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            message: message.into(),
+        }
+    }
+
+    fn response(self) -> HttpResponse {
+        HttpResponse::build(self.status).body(self.message)
+    }
+}
+
+impl From<database::ntehelper_tracker::DbTrackerUidClaim> for TrackerUidClaimResponse {
+    fn from(claim: database::ntehelper_tracker::DbTrackerUidClaim) -> Self {
+        TrackerUidClaimResponse {
+            uid: claim.uid.to_string(),
+            nickname: claim.nickname,
+            owner_username: claim.owner_username,
+            claim_source: claim.claim_source,
+            has_profile: claim.has_profile,
+            claimed_at: claim.claimed_at,
+            updated_at: claim.updated_at,
+        }
+    }
+}
+
+impl From<database::ntehelper_tracker::DbTrackerPull> for TrackerPullResponse {
+    fn from(pull: database::ntehelper_tracker::DbTrackerPull) -> Self {
+        TrackerPullResponse {
+            uid: pull.uid.to_string(),
+            record_uid: pull.record_uid,
+            pool_group_id: pull.pool_group_id,
+            banner_type: pull.banner_type,
+            timestamp_raw: pull.timestamp_raw,
+            timestamp_group_ordinal: pull.timestamp_group_ordinal.unwrap_or_default(),
+            reward_type: pull.reward_type,
+            reward_id: pull.reward_id,
+            reward_name: pull.reward_name,
+            reward_rank: pull.reward_rank,
+            star_rank: pull.star_rank,
+            roll_result: pull.roll_result,
+            result_type: pull.result_type,
+            quantity: pull.quantity,
+            source_type: Some("exporter".to_string()),
+            imported_at: pull.imported_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_export(pool_group_id: &str, rank: Option<&str>) -> RawTrackerExport {
+        RawTrackerExport {
+            format: "nte-history-export".to_string(),
+            format_version: 1,
+            user_uid: "211234567890".to_string(),
+            banner: RawTrackerBanner {
+                id: pool_group_id.to_string(),
+            },
+            records: vec![RawTrackerRecord {
+                uid: "a940530e488a0e537af6070043fbc19a".to_string(),
+                pool_group_id: pool_group_id.to_string(),
+                timestamp: "2026-06-07 19:28:21".to_string(),
+                timestamp_group_ordinal: 0,
+                roll_result: Some(5),
+                result_type: Some("dice".to_string()),
+                reward_type: "arc".to_string(),
+                reward_id: "fork_vine".to_string(),
+                reward_name: "Be Happy".to_string(),
+                reward_rank: rank.map(str::to_string),
+                quantity: Some(1),
+            }],
+        }
+    }
+
+    #[test]
+    fn validates_numeric_tracker_uids() {
+        assert_eq!(validate_tracker_uid("211234567890"), Some(211234567890));
+        assert_eq!(validate_tracker_uid("abc"), None);
+        assert_eq!(validate_tracker_uid("221234567890"), None);
+        assert_eq!(validate_tracker_uid("21123456789"), None);
+    }
+
+    #[test]
+    fn normalizes_known_export_pools_and_ranks() {
+        let uid = 211234567890;
+        let body = TrackerImportRequest {
+            exports: vec![
+                sample_export("Lottery_LimitedCharacter", Some("S")),
+                sample_export("Lottery_Permanent", Some("A")),
+                sample_export("Arc_MiracleBox", None),
+            ],
+        };
+
+        let (pulls, received) = normalize_tracker_exports(uid, body).unwrap();
+
+        assert_eq!(received, 3);
+        assert_eq!(pulls.len(), 1);
+        let pull = pulls.first().unwrap();
+        assert_eq!(pull.uid, uid);
+        assert_eq!(pull.star_rank, None);
+        assert_eq!(pull.banner_type, "arc");
+    }
+
+    #[test]
+    fn rejects_malformed_tracker_records() {
+        let uid = 211234567890;
+        let mut export = sample_export("Lottery_LimitedCharacter", Some("S"));
+        export.records[0].timestamp = "2026/06/07".to_string();
+
+        assert!(normalize_tracker_exports(
+            uid,
+            TrackerImportRequest {
+                exports: vec![export],
+            },
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_mismatched_export_user_uid() {
+        let mut export = sample_export("Lottery_LimitedCharacter", Some("S"));
+        export.user_uid = "211234567891".to_string();
+
+        let error = match normalize_tracker_exports(
+            211234567890,
+            TrackerImportRequest {
+                exports: vec![export],
+            },
+        ) {
+            Ok(_) => panic!("expected mismatched user_uid import to fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.message, "Import UID does not match target tracker UID");
+    }
+
+    #[test]
+    fn tracker_claim_detach_migration_allows_multiple_self_claims() {
+        let migration = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/migrations/20260616010000_ntehelper_tracker_claim_detach.sql"
+        ));
+
+        assert!(migration.contains("CREATE INDEX ntehelper_tracker_uid_claim_self_owner_idx"));
+        assert!(!migration.contains("CREATE UNIQUE INDEX ntehelper_tracker_uid_claim_self_owner_idx"));
+    }
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -14,6 +14,7 @@ pub mod light_cones;
 pub mod light_cones_text;
 pub mod mihomo;
 pub mod ntehelper;
+pub mod ntehelper_tracker;
 pub mod sessions;
 pub mod users;
 pub mod users_achievements_completed;

--- a/src/database/ntehelper.rs
+++ b/src/database/ntehelper.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use sqlx::{FromRow, PgPool, Postgres, Transaction};
-
 #[derive(FromRow)]
 pub struct DbCompletion {
     pub kind: String,
@@ -29,6 +28,7 @@ pub struct DbMarkerComment {
     pub marker_key: String,
     pub username: String,
     pub body: String,
+    pub screenshot_urls: Value,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub score: i64,
@@ -193,6 +193,7 @@ pub async fn list_marker_comments(
              c.marker_key,
              u.username,
              c.body,
+             c.screenshot_urls,
              c.created_at,
              c.updated_at,
              COALESCE(SUM(v.value), 0)::bigint AS score,
@@ -206,7 +207,7 @@ pub async fn list_marker_comments(
            LEFT JOIN ntehelper_marker_comment_vote viewer_vote
              ON viewer_vote.comment_id = c.id AND viewer_vote.user_id = $2
            WHERE c.marker_key = $1 AND c.deleted_at IS NULL
-           GROUP BY c.id, c.marker_key, c.user_id, u.username, c.body, c.created_at, c.updated_at, viewer_vote.value
+           GROUP BY c.id, c.marker_key, c.user_id, u.username, c.body, c.screenshot_urls, c.created_at, c.updated_at, viewer_vote.value
            ORDER BY score DESC, c.created_at DESC, c.id DESC
            OFFSET $3
            LIMIT $4"#,
@@ -223,15 +224,17 @@ pub async fn create_marker_comment(
     username: &str,
     marker_key: &str,
     body: &str,
+    screenshot_urls: &Value,
     pool: &PgPool,
 ) -> Result<DbMarkerComment> {
     let user_id = get_user_id(username, pool).await?;
     let comment_id = sqlx::query_scalar::<_, i64>(
-        "INSERT INTO ntehelper_marker_comment (marker_key, user_id, body) VALUES ($1, $2, $3) RETURNING id",
+        "INSERT INTO ntehelper_marker_comment (marker_key, user_id, body, screenshot_urls) VALUES ($1, $2, $3, $4) RETURNING id",
     )
     .bind(marker_key)
     .bind(user_id)
     .bind(body)
+    .bind(screenshot_urls)
     .fetch_one(pool)
     .await?;
 
@@ -244,17 +247,19 @@ pub async fn update_marker_comment(
     comment_id: i64,
     username: &str,
     body: &str,
+    screenshot_urls: &Value,
     pool: &PgPool,
 ) -> Result<Option<DbMarkerComment>> {
     let user_id = get_user_id(username, pool).await?;
     let updated_id = sqlx::query_scalar::<_, i64>(
-        "UPDATE ntehelper_marker_comment SET body = $3, updated_at = now()
+        "UPDATE ntehelper_marker_comment SET body = $3, screenshot_urls = $4, updated_at = now()
          WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
          RETURNING id",
     )
     .bind(comment_id)
     .bind(user_id)
     .bind(body)
+    .bind(screenshot_urls)
     .fetch_optional(pool)
     .await?;
 
@@ -374,6 +379,7 @@ async fn get_marker_comment(
              c.marker_key,
              u.username,
              c.body,
+             c.screenshot_urls,
              c.created_at,
              c.updated_at,
              COALESCE(SUM(v.value), 0)::bigint AS score,
@@ -387,7 +393,7 @@ async fn get_marker_comment(
            LEFT JOIN ntehelper_marker_comment_vote viewer_vote
              ON viewer_vote.comment_id = c.id AND viewer_vote.user_id = $2
            WHERE c.id = $1 AND c.deleted_at IS NULL
-           GROUP BY c.id, c.marker_key, c.user_id, u.username, c.body, c.created_at, c.updated_at, viewer_vote.value"#,
+           GROUP BY c.id, c.marker_key, c.user_id, u.username, c.body, c.screenshot_urls, c.created_at, c.updated_at, viewer_vote.value"#,
     )
     .bind(comment_id)
     .bind(viewer_user_id)

--- a/src/database/ntehelper_tracker.rs
+++ b/src/database/ntehelper_tracker.rs
@@ -1,0 +1,711 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use sqlx::{FromRow, PgPool};
+use std::{
+    error::Error,
+    fmt,
+    sync::atomic::{AtomicI64, Ordering},
+};
+
+#[derive(Debug, FromRow, Clone)]
+pub struct DbTrackerUidClaim {
+    pub uid: i64,
+    pub nickname: String,
+    pub owner_user_id: Option<i64>,
+    pub owner_username: Option<String>,
+    pub claim_source: String,
+    pub has_profile: bool,
+    pub claimed_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, FromRow, Clone)]
+pub struct DbTrackerPull {
+    pub uid: i64,
+    pub record_uid: String,
+    pub pool_group_id: String,
+    pub banner_type: String,
+    pub timestamp_raw: String,
+    pub timestamp_group_ordinal: Option<i32>,
+    pub roll_result: Option<i32>,
+    pub result_type: Option<String>,
+    pub reward_type: String,
+    pub reward_id: String,
+    pub reward_name: String,
+    pub reward_rank: Option<String>,
+    pub star_rank: Option<i32>,
+    pub quantity: Option<i32>,
+    pub imported_at: DateTime<Utc>,
+}
+
+pub struct TrackerImportResult {
+    pub inserted: i64,
+    pub total: i64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TrackerClaimError {
+    AlreadyClaimed,
+    SelfClaimLimit,
+    NotOwnedByUser,
+}
+
+impl fmt::Display for TrackerClaimError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TrackerClaimError::AlreadyClaimed => f.write_str("tracker UID is already claimed"),
+            TrackerClaimError::SelfClaimLimit => {
+                f.write_str("account already has the maximum number of self-claimed tracker UIDs")
+            }
+            TrackerClaimError::NotOwnedByUser => {
+                f.write_str("tracker UID is not attached to this account")
+            }
+        }
+    }
+}
+
+impl Error for TrackerClaimError {}
+
+pub async fn get_tracker_user_id(username: &str, pool: &PgPool) -> Result<i64> {
+    Ok(
+        sqlx::query_scalar!("SELECT id FROM users WHERE username = $1", username)
+            .fetch_one(pool)
+            .await?,
+    )
+}
+
+pub async fn tracker_claims_for_user(
+    owner_user_id: i64,
+    pool: &PgPool,
+) -> Result<Vec<DbTrackerUidClaim>> {
+    Ok(sqlx::query_as::<_, DbTrackerUidClaim>(
+        r#"SELECT
+             c.uid,
+             c.nickname,
+             c.owner_user_id,
+             u.username AS owner_username,
+             c.claim_source,
+             EXISTS(SELECT 1 FROM ntehelper_tracker_pull p WHERE p.uid = c.uid) AS has_profile,
+             c.claimed_at,
+             c.updated_at
+           FROM ntehelper_tracker_uid_claim c
+           JOIN users u ON u.id = c.owner_user_id
+           WHERE c.owner_user_id = $1
+           ORDER BY c.claimed_at DESC, c.uid"#,
+    )
+    .bind(owner_user_id)
+    .fetch_all(pool)
+    .await?)
+}
+
+pub async fn get_tracker_claim(uid: i64, pool: &PgPool) -> Result<Option<DbTrackerUidClaim>> {
+    Ok(sqlx::query_as::<_, DbTrackerUidClaim>(
+        r#"SELECT
+             c.uid,
+             c.nickname,
+             c.owner_user_id,
+             u.username AS owner_username,
+             c.claim_source,
+             EXISTS(SELECT 1 FROM ntehelper_tracker_pull p WHERE p.uid = c.uid) AS has_profile,
+             c.claimed_at,
+             c.updated_at
+           FROM ntehelper_tracker_uid_claim c
+           LEFT JOIN users u ON u.id = c.owner_user_id
+           WHERE c.uid = $1"#,
+    )
+    .bind(uid)
+    .fetch_optional(pool)
+    .await?)
+}
+
+pub async fn claim_tracker_uid(
+    owner_user_id: i64,
+    uid: i64,
+    max_self_claims: i64,
+    pool: &PgPool,
+) -> Result<std::result::Result<DbTrackerUidClaim, TrackerClaimError>> {
+    let mut tx = pool.begin().await?;
+
+    // Serialize self-claim evaluation per user so concurrent requests cannot
+    // each observe the same pre-limit count and exceed the cap together.
+    sqlx::query("SELECT id FROM users WHERE id = $1 FOR UPDATE")
+        .bind(owner_user_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+    let existing_claim = sqlx::query_scalar::<_, i64>(
+        "SELECT owner_user_id FROM ntehelper_tracker_uid_claim WHERE uid = $1 AND owner_user_id IS NOT NULL",
+    )
+    .bind(uid)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if let Some(existing_owner_id) = existing_claim {
+        tx.rollback().await?;
+        if existing_owner_id == owner_user_id {
+            return Ok(Ok(get_tracker_claim(uid, pool)
+                .await?
+                .expect("existing tracker claim should load")));
+        }
+
+        return Ok(Err(TrackerClaimError::AlreadyClaimed));
+    }
+
+    let existing_self_claim = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*)::bigint FROM ntehelper_tracker_uid_claim WHERE owner_user_id = $1 AND claim_source = 'self'",
+    )
+    .bind(owner_user_id)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if existing_self_claim >= max_self_claims {
+        tx.rollback().await?;
+        return Ok(Err(TrackerClaimError::SelfClaimLimit));
+    }
+
+    let attach_existing = sqlx::query(
+        "UPDATE ntehelper_tracker_uid_claim
+         SET owner_user_id = $2, claim_source = 'self', updated_at = now()
+         WHERE uid = $1 AND owner_user_id IS NULL",
+    )
+    .bind(uid)
+    .bind(owner_user_id)
+    .execute(&mut *tx)
+    .await?;
+
+    if attach_existing.rows_affected() == 0 {
+        let insert_result = sqlx::query(
+            "INSERT INTO ntehelper_tracker_uid_claim (uid, owner_user_id, claim_source, nickname) VALUES ($1, $2, 'self', '')",
+        )
+        .bind(uid)
+        .bind(owner_user_id)
+        .execute(&mut *tx)
+        .await;
+
+        if let Err(error) = insert_result {
+            tx.rollback().await?;
+            if let sqlx::Error::Database(database_error) = &error {
+                if database_error.code().as_deref() == Some("23505") {
+                    if let Some(existing) = get_tracker_claim(uid, pool).await? {
+                        return Ok(if existing.owner_user_id == Some(owner_user_id) {
+                            Ok(existing)
+                        } else {
+                            Err(TrackerClaimError::AlreadyClaimed)
+                        });
+                    }
+
+                    return Ok(Err(TrackerClaimError::SelfClaimLimit));
+                }
+            }
+
+            return Err(error.into());
+        }
+    }
+
+    tx.commit().await?;
+
+    Ok(Ok(get_tracker_claim(uid, pool)
+        .await?
+        .expect("created tracker claim should load")))
+}
+
+pub async fn update_tracker_claim_nickname(
+    owner_user_id: i64,
+    uid: i64,
+    nickname: &str,
+    pool: &PgPool,
+) -> Result<std::result::Result<DbTrackerUidClaim, TrackerClaimError>> {
+    let result = sqlx::query(
+        "UPDATE ntehelper_tracker_uid_claim
+         SET nickname = $3, updated_at = now()
+         WHERE uid = $1 AND owner_user_id = $2",
+    )
+    .bind(uid)
+    .bind(owner_user_id)
+    .bind(nickname)
+    .execute(pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Ok(Err(TrackerClaimError::NotOwnedByUser));
+    }
+
+    Ok(Ok(get_tracker_claim(uid, pool)
+        .await?
+        .expect("updated tracker claim should load")))
+}
+
+pub async fn delete_tracker_uid_profile(
+    owner_user_id: i64,
+    uid: i64,
+    pool: &PgPool,
+) -> Result<std::result::Result<i64, TrackerClaimError>> {
+    let mut tx = pool.begin().await?;
+    let deleted_pulls = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*)::bigint FROM ntehelper_tracker_pull WHERE uid = $1",
+    )
+    .bind(uid)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let deleted_claim = sqlx::query(
+        "DELETE FROM ntehelper_tracker_uid_claim WHERE uid = $1 AND owner_user_id = $2",
+    )
+    .bind(uid)
+    .bind(owner_user_id)
+    .execute(&mut *tx)
+    .await?;
+
+    if deleted_claim.rows_affected() == 0 {
+        tx.rollback().await?;
+        return Ok(Err(TrackerClaimError::NotOwnedByUser));
+    }
+
+    tx.commit().await?;
+
+    Ok(Ok(deleted_pulls))
+}
+
+pub async fn tracker_pulls_for_uid(uid: i64, pool: &PgPool) -> Result<Vec<DbTrackerPull>> {
+    Ok(sqlx::query_as::<_, DbTrackerPull>(
+        r#"SELECT
+             uid,
+             record_uid,
+             pool_group_id,
+             banner_type,
+             timestamp_raw,
+             timestamp_group_ordinal,
+             roll_result,
+             result_type,
+             reward_type,
+             reward_id,
+             reward_name,
+             reward_rank,
+             star_rank,
+             quantity,
+             imported_at
+           FROM ntehelper_tracker_pull
+           WHERE uid = $1
+           ORDER BY timestamp_raw DESC, timestamp_group_ordinal DESC NULLS LAST, record_uid DESC"#,
+    )
+    .bind(uid)
+    .fetch_all(pool)
+    .await?)
+}
+
+pub async fn tracker_pull_count(uid: i64, pool: &PgPool) -> Result<i64> {
+    Ok(sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*)::bigint FROM ntehelper_tracker_pull WHERE uid = $1",
+    )
+    .bind(uid)
+    .fetch_one(pool)
+    .await?)
+}
+
+pub async fn import_tracker_pulls(
+    uid: i64,
+    pulls: &[DbTrackerPull],
+    max_total: i64,
+    pool: &PgPool,
+) -> Result<Option<TrackerImportResult>> {
+    if pulls.is_empty() {
+        let total = tracker_pull_count(uid, pool).await?;
+        return Ok(Some(TrackerImportResult { inserted: 0, total }));
+    }
+
+    let record_uids = pulls
+        .iter()
+        .map(|pull| pull.record_uid.clone())
+        .collect::<Vec<_>>();
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("SELECT uid FROM ntehelper_tracker_uid_claim WHERE uid = $1 FOR UPDATE")
+        .bind(uid)
+        .fetch_one(&mut *tx)
+        .await?;
+
+    let current_total = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*)::bigint FROM ntehelper_tracker_pull WHERE uid = $1",
+    )
+    .bind(uid)
+    .fetch_one(&mut *tx)
+    .await?;
+    let new_count = sqlx::query_scalar::<_, i64>(
+        r#"SELECT COUNT(*)::bigint
+           FROM unnest($2::text[]) AS incoming(record_uid)
+           WHERE NOT EXISTS (
+               SELECT 1 FROM ntehelper_tracker_pull p
+               WHERE p.uid = $1 AND p.record_uid = incoming.record_uid
+           )"#,
+    )
+    .bind(uid)
+    .bind(&record_uids)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if current_total + new_count > max_total {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    let mut inserted = 0;
+
+    for pull in pulls {
+        let result = sqlx::query(
+            r#"INSERT INTO ntehelper_tracker_pull (
+                 uid,
+                 record_uid,
+                 pool_group_id,
+                 banner_type,
+                 timestamp_raw,
+                 timestamp_group_ordinal,
+                 roll_result,
+                 result_type,
+                 reward_type,
+                 reward_id,
+                 reward_name,
+                 reward_rank,
+                 star_rank,
+                 quantity
+               ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+               ON CONFLICT (uid, record_uid) DO NOTHING"#,
+        )
+        .bind(pull.uid)
+        .bind(&pull.record_uid)
+        .bind(&pull.pool_group_id)
+        .bind(&pull.banner_type)
+        .bind(&pull.timestamp_raw)
+        .bind(pull.timestamp_group_ordinal)
+        .bind(pull.roll_result)
+        .bind(&pull.result_type)
+        .bind(&pull.reward_type)
+        .bind(&pull.reward_id)
+        .bind(&pull.reward_name)
+        .bind(&pull.reward_rank)
+        .bind(pull.star_rank)
+        .bind(pull.quantity)
+        .execute(&mut *tx)
+        .await?;
+
+        inserted += result.rows_affected() as i64;
+    }
+
+    sqlx::query("UPDATE ntehelper_tracker_uid_claim SET updated_at = now() WHERE uid = $1")
+        .bind(uid)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok(Some(TrackerImportResult {
+        inserted,
+        total: current_total + inserted,
+    }))
+}
+
+pub async fn clear_tracker_pulls(uid: i64, pool: &PgPool) -> Result<i64> {
+    let mut tx = pool.begin().await?;
+    let result = sqlx::query("DELETE FROM ntehelper_tracker_pull WHERE uid = $1")
+        .bind(uid)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("UPDATE ntehelper_tracker_uid_claim SET updated_at = now() WHERE uid = $1")
+        .bind(uid)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok(result.rows_affected() as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::users::{self, DbUser};
+    use sqlx::postgres::PgPoolOptions;
+    use uuid::Uuid;
+
+    static NEXT_UID_OFFSET: AtomicI64 = AtomicI64::new(0);
+
+    fn next_uid() -> i64 {
+        let suffix = (Utc::now().timestamp_micros() % 10_000_000_000)
+            + NEXT_UID_OFFSET.fetch_add(1, Ordering::Relaxed);
+        210_000_000_000 + (suffix % 10_000_000_000)
+    }
+
+    async fn test_pool() -> PgPool {
+        let _ = dotenv::dotenv();
+        let database_url =
+            std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for DB-backed tests");
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("test database should connect");
+        sqlx::migrate!()
+            .run(&pool)
+            .await
+            .expect("test database migrations should run");
+        pool
+    }
+
+    async fn create_test_user(pool: &PgPool) -> (String, i64) {
+        let username = format!("tracker_test_{}", Uuid::new_v4().simple());
+        let user = DbUser {
+            username: username.clone(),
+            password: "test-password-hash".to_string(),
+            email: Some(format!("{username}@example.com")),
+        };
+        users::set(&user, pool)
+            .await
+            .expect("test user should insert successfully");
+        let user_id = get_tracker_user_id(&username, pool)
+            .await
+            .expect("test user id should load");
+        (username, user_id)
+    }
+
+    async fn delete_test_user(username: &str, pool: &PgPool) {
+        sqlx::query("DELETE FROM users WHERE username = $1")
+            .bind(username)
+            .execute(pool)
+            .await
+            .expect("test user should delete successfully");
+    }
+
+    async fn delete_test_claim(uid: i64, pool: &PgPool) {
+        sqlx::query("DELETE FROM ntehelper_tracker_uid_claim WHERE uid = $1")
+            .bind(uid)
+            .execute(pool)
+            .await
+            .expect("test claim should delete successfully");
+    }
+
+    fn sample_pull(uid: i64, record_uid: &str) -> DbTrackerPull {
+        DbTrackerPull {
+            uid,
+            record_uid: record_uid.to_string(),
+            pool_group_id: "Lottery_LimitedCharacter".to_string(),
+            banner_type: "limited-character".to_string(),
+            timestamp_raw: "2026-06-07 19:28:21".to_string(),
+            timestamp_group_ordinal: Some(0),
+            roll_result: Some(1),
+            result_type: Some("single".to_string()),
+            reward_type: "character".to_string(),
+            reward_id: "test_reward".to_string(),
+            reward_name: "Test Reward".to_string(),
+            reward_rank: Some("S".to_string()),
+            star_rank: Some(5),
+            quantity: Some(1),
+            imported_at: Utc::now(),
+        }
+    }
+
+    #[actix_web::test]
+    async fn tracker_claim_creation_roundtrip() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+        let uid = next_uid();
+
+        let claim = claim_tracker_uid(user_id, uid, 3, &pool)
+            .await
+            .expect("claim should succeed")
+            .expect("claim should be created");
+
+        assert_eq!(claim.uid, uid);
+        assert_eq!(claim.owner_user_id, Some(user_id));
+        assert_eq!(claim.claim_source, "self");
+        assert!(!claim.has_profile);
+
+        let claims = tracker_claims_for_user(user_id, &pool)
+            .await
+            .expect("claims should load");
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].uid, uid);
+
+        delete_test_user(&username, &pool).await;
+    }
+
+    #[actix_web::test]
+    async fn allows_three_self_claims_but_blocks_a_fourth() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+
+        for _ in 0..3 {
+            claim_tracker_uid(user_id, next_uid(), 3, &pool)
+                .await
+                .expect("claim should succeed")
+                .expect("claim should be created");
+        }
+
+        let error = claim_tracker_uid(user_id, next_uid(), 3, &pool)
+            .await
+            .expect("limit check should return a domain error")
+            .expect_err("fourth self-claim should be rejected");
+
+        assert_eq!(error, TrackerClaimError::SelfClaimLimit);
+
+        delete_test_user(&username, &pool).await;
+    }
+
+    #[actix_web::test]
+    async fn reattaches_detached_claim_with_existing_profile() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+        let uid = next_uid();
+
+        sqlx::query(
+            "INSERT INTO ntehelper_tracker_uid_claim (uid, owner_user_id, claim_source, nickname)
+             VALUES ($1, NULL, 'self', 'Detached UID')",
+        )
+        .bind(uid)
+        .execute(&pool)
+        .await
+        .expect("detached claim should insert");
+        import_tracker_pulls(uid, &[sample_pull(uid, "reattach-record")], 10, &pool)
+            .await
+            .expect("import should succeed")
+            .expect("import should not hit the limit");
+
+        claim_tracker_uid(user_id, uid, 3, &pool)
+            .await
+            .expect("reattach should succeed")
+            .expect("detached claim should reattach");
+
+        let claim = get_tracker_claim(uid, &pool)
+            .await
+            .expect("claim should load")
+            .expect("claim should exist");
+        assert_eq!(claim.owner_user_id, Some(user_id));
+        assert!(claim.has_profile);
+        assert_eq!(
+            tracker_pull_count(uid, &pool)
+                .await
+                .expect("pull count should load"),
+            1
+        );
+
+        delete_test_claim(uid, &pool).await;
+        delete_test_user(&username, &pool).await;
+    }
+
+    #[actix_web::test]
+    async fn clear_pulls_preserves_the_claim() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+        let uid = next_uid();
+
+        claim_tracker_uid(user_id, uid, 3, &pool)
+            .await
+            .expect("claim should succeed")
+            .expect("claim should be created");
+        import_tracker_pulls(
+            uid,
+            &[sample_pull(uid, "clear-1"), sample_pull(uid, "clear-2")],
+            10,
+            &pool,
+        )
+        .await
+        .expect("import should succeed")
+        .expect("import should not hit the limit");
+
+        let deleted = clear_tracker_pulls(uid, &pool)
+            .await
+            .expect("clear should succeed");
+
+        assert_eq!(deleted, 2);
+        assert_eq!(
+            tracker_pull_count(uid, &pool)
+                .await
+                .expect("pull count should load"),
+            0
+        );
+        let claim = get_tracker_claim(uid, &pool)
+            .await
+            .expect("claim should load")
+            .expect("claim should still exist");
+        assert_eq!(claim.owner_user_id, Some(user_id));
+        assert!(!claim.has_profile);
+
+        delete_test_user(&username, &pool).await;
+    }
+
+    #[actix_web::test]
+    async fn import_limit_rejects_records_over_the_cap() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+        let uid = next_uid();
+
+        claim_tracker_uid(user_id, uid, 3, &pool)
+            .await
+            .expect("claim should succeed")
+            .expect("claim should be created");
+        import_tracker_pulls(
+            uid,
+            &[sample_pull(uid, "limit-1"), sample_pull(uid, "limit-2")],
+            2,
+            &pool,
+        )
+        .await
+        .expect("initial import should succeed")
+        .expect("initial import should fit inside the limit");
+
+        let result = import_tracker_pulls(uid, &[sample_pull(uid, "limit-3")], 2, &pool)
+            .await
+            .expect("limit check should succeed");
+
+        assert!(result.is_none());
+        assert_eq!(
+            tracker_pull_count(uid, &pool)
+                .await
+                .expect("pull count should load"),
+            2
+        );
+
+        delete_test_user(&username, &pool).await;
+    }
+
+    #[actix_web::test]
+    async fn deleting_a_tracker_profile_removes_claim_and_pulls_atomically() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+        let uid = next_uid();
+
+        claim_tracker_uid(user_id, uid, 3, &pool)
+            .await
+            .expect("claim should succeed")
+            .expect("claim should be created");
+        import_tracker_pulls(
+            uid,
+            &[sample_pull(uid, "delete-1"), sample_pull(uid, "delete-2")],
+            10,
+            &pool,
+        )
+        .await
+        .expect("import should succeed")
+        .expect("import should not hit the limit");
+
+        let deleted_pulls = delete_tracker_uid_profile(user_id, uid, &pool)
+            .await
+            .expect("delete should succeed")
+            .expect("delete should be allowed");
+
+        assert_eq!(deleted_pulls, 2);
+        assert!(
+            get_tracker_claim(uid, &pool)
+                .await
+                .expect("claim lookup should succeed")
+                .is_none()
+        );
+        assert_eq!(
+            tracker_pull_count(uid, &pool)
+                .await
+                .expect("pull count should load"),
+            0
+        );
+
+        delete_test_user(&username, &pool).await;
+    }
+}

--- a/src/database/ntehelper_tracker.rs
+++ b/src/database/ntehelper_tracker.rs
@@ -4,7 +4,6 @@ use sqlx::{FromRow, PgPool};
 use std::{
     error::Error,
     fmt,
-    sync::atomic::{AtomicI64, Ordering},
 };
 
 #[derive(Debug, FromRow, Clone)]
@@ -425,6 +424,7 @@ mod tests {
     use super::*;
     use crate::database::users::{self, DbUser};
     use sqlx::postgres::PgPoolOptions;
+    use std::sync::atomic::{AtomicI64, Ordering};
     use uuid::Uuid;
 
     static NEXT_UID_OFFSET: AtomicI64 = AtomicI64::new(0);


### PR DESCRIPTION
## Summary
This PR adds the backend support for the NTE roll tracker feature and expands marker comments to store screenshot URLs.

## What’s included
- Adds NTE tracker claim/list/update/delete/import API routes
- Adds tracker database schema and migrations
- Splits tracker persistence into a dedicated `ntehelper_tracker` database module
- Enforces tracker import validation, including matching `user_uid`
- Adds atomic backend deletion for tracker profile + claim removal
- Adds DB-backed tracker lifecycle tests
- Adds screenshot URL support for marker comments
- Merges tracker OpenAPI docs into the existing NTE helper API docs

## Tracker behavior
- Users can self-claim up to 3 tracker UIDs
- Existing detached claims with stored pulls can be reattached
- Tracker imports reject malformed payloads and UID mismatches
- Deleting a tracker UID now removes the claim and stored profile data in one backend operation

## Marker comment changes
- Marker comments now accept and return `screenshotUrls`
- Screenshot URLs are validated, deduplicated, and limited
- Existing comment create/update/list flows now include screenshot URL persistence

## Verification
- `cargo test` passed, including new DB-backed tracker tests
- Tracker lifecycle coverage now includes:
  - claim creation
  - multiple self-claims
  - detached claimed UIDs with profiles
  - clear-pulls behavior
  - import limits
  - atomic delete behavior

## Notes
- This PR targets the backend only
- Frontend tracker integration and separate frontend verification were handled in the companion app worktree