### PR TITLE
Add claimed UID region support

### DIFF
--- a/migrations/20260627010000_ntehelper_tracker_claim_region.sql
+++ b/migrations/20260627010000_ntehelper_tracker_claim_region.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ntehelper_tracker_uid_claim
+ADD COLUMN region text NOT NULL DEFAULT 'europe';
+
+ALTER TABLE ntehelper_tracker_uid_claim
+ADD CONSTRAINT ntehelper_tracker_uid_claim_region_check
+CHECK (region IN ('asia', 'europe', 'america', 'china'));

--- a/src/api/ntehelper/tracker.rs
+++ b/src/api/ntehelper/tracker.rs
@@ -80,6 +80,7 @@ struct TrackerClaimsResponse {
 struct TrackerUidClaimResponse {
     uid: String,
     nickname: String,
+    region: String,
     owner_username: Option<String>,
     claim_source: String,
     has_profile: bool,
@@ -90,7 +91,8 @@ struct TrackerUidClaimResponse {
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct TrackerClaimUpdateRequest {
-    nickname: String,
+    nickname: Option<String>,
+    region: Option<String>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -285,15 +287,30 @@ async fn put_tracker_uid_claim(
     let Some(uid) = validate_tracker_uid(&uid) else {
         return Ok(HttpResponse::BadRequest().body("Invalid tracker UID"));
     };
-    let Some(nickname) = validate_tracker_nickname(&body.nickname) else {
-        return Ok(HttpResponse::BadRequest().body("Invalid tracker nickname"));
+    let nickname = match body.nickname.as_deref() {
+        Some(value) => match validate_tracker_nickname(value) {
+            Some(value) => Some(value),
+            None => return Ok(HttpResponse::BadRequest().body("Invalid tracker nickname")),
+        },
+        None => None,
     };
+    let region = match body.region.as_deref() {
+        Some(value) => match validate_tracker_region(value) {
+            Some(value) => Some(value),
+            None => return Ok(HttpResponse::BadRequest().body("Invalid tracker region")),
+        },
+        None => None,
+    };
+    if nickname.is_none() && region.is_none() {
+        return Ok(HttpResponse::BadRequest().body("Tracker claim update is empty"));
+    }
 
     let user_id = database::ntehelper_tracker::get_tracker_user_id(&username, &pool).await?;
-    let claim = match database::ntehelper_tracker::update_tracker_claim_nickname(
+    let claim = match database::ntehelper_tracker::update_tracker_claim(
         user_id,
         uid,
         nickname,
+        region,
         &pool,
     )
             .await?
@@ -552,6 +569,13 @@ fn validate_tracker_uid(value: &str) -> Option<i64> {
     }
 
     trimmed.parse::<i64>().ok()
+}
+
+fn validate_tracker_region(value: &str) -> Option<&str> {
+    match value.trim() {
+        "asia" | "europe" | "america" | "china" => Some(value.trim()),
+        _ => None,
+    }
 }
 
 fn validate_tracker_nickname(value: &str) -> Option<&str> {
@@ -817,6 +841,7 @@ impl From<database::ntehelper_tracker::DbTrackerUidClaim> for TrackerUidClaimRes
         TrackerUidClaimResponse {
             uid: claim.uid.to_string(),
             nickname: claim.nickname,
+            region: claim.region,
             owner_username: claim.owner_username,
             claim_source: claim.claim_source,
             has_profile: claim.has_profile,

--- a/src/database/ntehelper_tracker.rs
+++ b/src/database/ntehelper_tracker.rs
@@ -10,6 +10,7 @@ use std::{
 pub struct DbTrackerUidClaim {
     pub uid: i64,
     pub nickname: String,
+    pub region: String,
     pub owner_user_id: Option<i64>,
     pub owner_username: Option<String>,
     pub claim_source: String,
@@ -81,6 +82,7 @@ pub async fn tracker_claims_for_user(
         r#"SELECT
              c.uid,
              c.nickname,
+             c.region,
              c.owner_user_id,
              u.username AS owner_username,
              c.claim_source,
@@ -102,6 +104,7 @@ pub async fn get_tracker_claim(uid: i64, pool: &PgPool) -> Result<Option<DbTrack
         r#"SELECT
              c.uid,
              c.nickname,
+             c.region,
              c.owner_user_id,
              u.username AS owner_username,
              c.claim_source,
@@ -208,20 +211,24 @@ pub async fn claim_tracker_uid(
         .expect("created tracker claim should load")))
 }
 
-pub async fn update_tracker_claim_nickname(
+pub async fn update_tracker_claim(
     owner_user_id: i64,
     uid: i64,
-    nickname: &str,
+    nickname: Option<&str>,
+    region: Option<&str>,
     pool: &PgPool,
 ) -> Result<std::result::Result<DbTrackerUidClaim, TrackerClaimError>> {
     let result = sqlx::query(
         "UPDATE ntehelper_tracker_uid_claim
-         SET nickname = $3, updated_at = now()
+         SET nickname = COALESCE($3, nickname),
+             region = COALESCE($4, region),
+             updated_at = now()
          WHERE uid = $1 AND owner_user_id = $2",
     )
     .bind(uid)
     .bind(owner_user_id)
     .bind(nickname)
+    .bind(region)
     .execute(pool)
     .await?;
 


### PR DESCRIPTION
## Summary
Adds claimed UID region support to the NTE tracker flow.

## Changes
- add a migration for tracker claim region support
- update tracker API handling for claimed UID region data
- update tracker database logic to store and read the new region-related fields