### PR TITLE
Simplify tracker storage and add safe reimport repairs

### DIFF
--- a/migrations/20260709000000_ntehelper_tracker_drop_derived_reward_fields.sql
+++ b/migrations/20260709000000_ntehelper_tracker_drop_derived_reward_fields.sql
@@ -1,0 +1,13 @@
+DROP INDEX IF EXISTS ntehelper_tracker_pull_uid_banner_timestamp_idx;
+
+ALTER TABLE ntehelper_tracker_pull
+    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_reward_type_check,
+    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_reward_name_check,
+    DROP CONSTRAINT IF EXISTS ntehelper_tracker_pull_star_rank_check;
+
+ALTER TABLE ntehelper_tracker_pull
+    DROP COLUMN IF EXISTS banner_type,
+    DROP COLUMN IF EXISTS reward_type,
+    DROP COLUMN IF EXISTS reward_name,
+    DROP COLUMN IF EXISTS reward_rank,
+    DROP COLUMN IF EXISTS star_rank;

--- a/src/api/ntehelper/tracker.rs
+++ b/src/api/ntehelper/tracker.rs
@@ -115,14 +115,9 @@ struct TrackerPullResponse {
     uid: String,
     record_uid: String,
     pool_group_id: String,
-    banner_type: String,
     timestamp_raw: String,
     timestamp_group_ordinal: i32,
-    reward_type: String,
     reward_id: String,
-    reward_name: String,
-    reward_rank: Option<String>,
-    star_rank: Option<i32>,
     roll_result: Option<i32>,
     result_type: Option<String>,
     quantity: Option<i32>,
@@ -142,6 +137,7 @@ struct TrackerImportResponse {
     uid: String,
     received: usize,
     imported: i64,
+    updated: i64,
     skipped_duplicate: i64,
     inserted: i64,
     duplicates: i64,
@@ -171,10 +167,13 @@ struct RawTrackerRecord {
     timestamp_group_ordinal: i32,
     roll_result: Option<i32>,
     result_type: Option<String>,
-    reward_type: String,
+    #[serde(rename = "reward_type")]
+    _reward_type: Option<String>,
     reward_id: String,
-    reward_name: String,
-    reward_rank: Option<String>,
+    #[serde(rename = "reward_name")]
+    _reward_name: Option<String>,
+    #[serde(rename = "reward_rank")]
+    _reward_rank: Option<String>,
     quantity: Option<i32>,
 }
 
@@ -448,12 +447,14 @@ async fn post_tracker_import(
     };
 
     let imported = result.inserted;
-    let skipped_duplicate = received.saturating_sub(imported as usize) as i64;
+    let updated = result.updated;
+    let skipped_duplicate = received.saturating_sub((imported + updated) as usize) as i64;
 
     Ok(HttpResponse::Ok().json(TrackerImportResponse {
         uid: uid.to_string(),
         received,
         imported,
+        updated,
         skipped_duplicate,
         inserted: imported,
         duplicates: skipped_duplicate,
@@ -645,7 +646,7 @@ fn normalize_tracker_exports(
             ));
         }
 
-        let banner_type = banner_type_for_pool(&export.banner.id)
+        banner_type_for_pool(&export.banner.id)
             .ok_or_else(|| TrackerImportError::bad_request("Unsupported tracker banner"))?;
 
         for record in export.records {
@@ -662,22 +663,10 @@ fn normalize_tracker_exports(
                 TRACKER_REWARD_TEXT_MAX_CHARS,
                 "reward ID",
             )?;
-            let reward_type =
-                safe_text(&record.reward_type, TRACKER_TEXT_MAX_CHARS, "reward type")?;
-            let reward_name = safe_display_text(
-                &record.reward_name,
-                TRACKER_REWARD_TEXT_MAX_CHARS,
-                "reward name",
-            )?;
             let result_type = record
                 .result_type
                 .map(|value| safe_text(&value, TRACKER_TEXT_MAX_CHARS, "result type"))
                 .transpose()?;
-            let reward_rank = record
-                .reward_rank
-                .map(|rank| normalize_rank(&rank))
-                .transpose()?;
-            let star_rank = star_rank_for_reward_rank(reward_rank.as_deref());
 
             if !valid_timestamp(&record.timestamp) {
                 return Err(TrackerImportError::bad_request("Invalid tracker timestamp"));
@@ -697,16 +686,11 @@ fn normalize_tracker_exports(
                     uid,
                     record_uid,
                     pool_group_id: export.banner.id.clone(),
-                    banner_type: banner_type.to_string(),
                     timestamp_raw: record.timestamp,
                     timestamp_group_ordinal: Some(record.timestamp_group_ordinal),
                     roll_result: record.roll_result,
                     result_type,
-                    reward_type,
                     reward_id,
-                    reward_name,
-                    reward_rank,
-                    star_rank,
                     quantity: record.quantity,
                     imported_at: Utc::now(),
                 },
@@ -723,22 +707,6 @@ fn banner_type_for_pool(pool_group_id: &str) -> Option<&'static str> {
         "Lottery_Permanent" => Some("permanent-character"),
         "Arc_MiracleBox" => Some("arc"),
         _ => None,
-    }
-}
-
-fn star_rank_for_reward_rank(rank: Option<&str>) -> Option<i32> {
-    match rank {
-        Some("S") => Some(5),
-        Some("A") => Some(4),
-        Some("B") => Some(3),
-        _ => None,
-    }
-}
-
-fn normalize_rank(rank: &str) -> Result<String, TrackerImportError> {
-    match rank.trim() {
-        "S" | "A" | "B" => Ok(rank.trim().to_string()),
-        _ => Err(TrackerImportError::bad_request("Unsupported reward rank")),
     }
 }
 
@@ -771,22 +739,6 @@ fn safe_text(
         || !trimmed
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':'))
-    {
-        return Err(TrackerImportError::bad_request(format!("Invalid {label}")));
-    }
-
-    Ok(trimmed.to_string())
-}
-
-fn safe_display_text(
-    value: &str,
-    max_chars: usize,
-    label: &'static str,
-) -> Result<String, TrackerImportError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty()
-        || trimmed.chars().count() > max_chars
-        || trimmed.chars().any(char::is_control)
     {
         return Err(TrackerImportError::bad_request(format!("Invalid {label}")));
     }
@@ -857,14 +809,9 @@ impl From<database::ntehelper_tracker::DbTrackerPull> for TrackerPullResponse {
             uid: pull.uid.to_string(),
             record_uid: pull.record_uid,
             pool_group_id: pull.pool_group_id,
-            banner_type: pull.banner_type,
             timestamp_raw: pull.timestamp_raw,
             timestamp_group_ordinal: pull.timestamp_group_ordinal.unwrap_or_default(),
-            reward_type: pull.reward_type,
             reward_id: pull.reward_id,
-            reward_name: pull.reward_name,
-            reward_rank: pull.reward_rank,
-            star_rank: pull.star_rank,
             roll_result: pull.roll_result,
             result_type: pull.result_type,
             quantity: pull.quantity,
@@ -893,10 +840,10 @@ mod tests {
                 timestamp_group_ordinal: 0,
                 roll_result: Some(5),
                 result_type: Some("dice".to_string()),
-                reward_type: "arc".to_string(),
+                _reward_type: Some("arc".to_string()),
                 reward_id: "fork_vine".to_string(),
-                reward_name: "Be Happy".to_string(),
-                reward_rank: rank.map(str::to_string),
+                _reward_name: Some("Be Happy".to_string()),
+                _reward_rank: rank.map(str::to_string),
                 quantity: Some(1),
             }],
         }
@@ -927,12 +874,11 @@ mod tests {
         assert_eq!(pulls.len(), 1);
         let pull = pulls.first().unwrap();
         assert_eq!(pull.uid, uid);
-        assert_eq!(pull.star_rank, Some(3));
-        assert_eq!(pull.banner_type, "arc");
+        assert_eq!(pull.pool_group_id, "Arc_MiracleBox");
     }
 
     #[test]
-    fn preserves_export_metadata_for_unknown_reward_ids() {
+    fn ignores_stale_export_metadata_for_unknown_reward_ids() {
         let uid = 211234567890;
         let body = TrackerImportRequest {
             exports: vec![RawTrackerExport {
@@ -949,10 +895,10 @@ mod tests {
                     timestamp_group_ordinal: 3,
                     roll_result: Some(1),
                     result_type: Some("dice".to_string()),
-                    reward_type: "item".to_string(),
+                    _reward_type: Some("item".to_string()),
                     reward_id: "mystery_reward".to_string(),
-                    reward_name: "Mystery Reward".to_string(),
-                    reward_rank: Some("A".to_string()),
+                    _reward_name: Some("Mystery Reward".to_string()),
+                    _reward_rank: Some("A".to_string()),
                     quantity: Some(1),
                 }],
             }],
@@ -963,11 +909,11 @@ mod tests {
         assert_eq!(received, 1);
         assert_eq!(pulls.len(), 1);
         let pull = pulls.first().unwrap();
-        assert_eq!(pull.reward_type, "item");
         assert_eq!(pull.reward_id, "mystery_reward");
-        assert_eq!(pull.reward_name, "Mystery Reward");
-        assert_eq!(pull.reward_rank, Some("A".to_string()));
-        assert_eq!(pull.star_rank, Some(4));
+        assert_eq!(pull.timestamp_raw, "2026-07-08 07:12:37");
+        assert_eq!(pull.roll_result, Some(1));
+        assert_eq!(pull.result_type, Some("dice".to_string()));
+        assert_eq!(pull.quantity, Some(1));
     }
 
     #[test]

--- a/src/database/ntehelper_tracker.rs
+++ b/src/database/ntehelper_tracker.rs
@@ -24,23 +24,24 @@ pub struct DbTrackerPull {
     pub uid: i64,
     pub record_uid: String,
     pub pool_group_id: String,
-    pub banner_type: String,
     pub timestamp_raw: String,
     pub timestamp_group_ordinal: Option<i32>,
     pub roll_result: Option<i32>,
     pub result_type: Option<String>,
-    pub reward_type: String,
     pub reward_id: String,
-    pub reward_name: String,
-    pub reward_rank: Option<String>,
-    pub star_rank: Option<i32>,
     pub quantity: Option<i32>,
     pub imported_at: DateTime<Utc>,
 }
 
 pub struct TrackerImportResult {
     pub inserted: i64,
+    pub updated: i64,
     pub total: i64,
+}
+
+#[derive(Debug, FromRow, Clone)]
+struct ExistingTrackerPullRecordUid {
+    pub record_uid: String,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -278,16 +279,11 @@ pub async fn tracker_pulls_for_uid(uid: i64, pool: &PgPool) -> Result<Vec<DbTrac
              uid,
              record_uid,
              pool_group_id,
-             banner_type,
              timestamp_raw,
              timestamp_group_ordinal,
              roll_result,
              result_type,
-             reward_type,
              reward_id,
-             reward_name,
-             reward_rank,
-             star_rank,
              quantity,
              imported_at
            FROM ntehelper_tracker_pull
@@ -316,7 +312,11 @@ pub async fn import_tracker_pulls(
 ) -> Result<Option<TrackerImportResult>> {
     if pulls.is_empty() {
         let total = tracker_pull_count(uid, pool).await?;
-        return Ok(Some(TrackerImportResult { inserted: 0, total }));
+        return Ok(Some(TrackerImportResult {
+            inserted: 0,
+            updated: 0,
+            total,
+        }));
     }
 
     let record_uids = pulls
@@ -348,6 +348,20 @@ pub async fn import_tracker_pulls(
     .bind(&record_uids)
     .fetch_one(&mut *tx)
     .await?;
+    let existing_pulls = sqlx::query_as::<_, ExistingTrackerPullRecordUid>(
+        r#"SELECT
+             record_uid
+           FROM ntehelper_tracker_pull
+           WHERE uid = $1 AND record_uid = ANY($2::text[])"#,
+    )
+    .bind(uid)
+    .bind(&record_uids)
+    .fetch_all(&mut *tx)
+    .await?;
+    let existing_by_record_uid = existing_pulls
+        .into_iter()
+        .map(|pull| (pull.record_uid.clone(), pull))
+        .collect::<std::collections::HashMap<_, _>>();
 
     if current_total + new_count > max_total {
         tx.rollback().await?;
@@ -355,44 +369,56 @@ pub async fn import_tracker_pulls(
     }
 
     let mut inserted = 0;
+    let mut updated = 0;
 
     for pull in pulls {
+        if existing_by_record_uid.contains_key(&pull.record_uid) {
+            let result = sqlx::query(
+                r#"UPDATE ntehelper_tracker_pull
+                   SET roll_result = $3,
+                       result_type = $4,
+                       quantity = $5
+                   WHERE uid = $1
+                     AND record_uid = $2
+                     AND (
+                        roll_result IS DISTINCT FROM $3
+                        OR result_type IS DISTINCT FROM $4
+                        OR quantity IS DISTINCT FROM $5
+                     )"#,
+            )
+            .bind(pull.uid)
+            .bind(&pull.record_uid)
+            .bind(pull.roll_result)
+            .bind(&pull.result_type)
+            .bind(pull.quantity)
+            .execute(&mut *tx)
+            .await?;
+
+            updated += result.rows_affected() as i64;
+            continue;
+        }
+
         let result = sqlx::query(
             r#"INSERT INTO ntehelper_tracker_pull (
                  uid,
                  record_uid,
                  pool_group_id,
-                 banner_type,
                  timestamp_raw,
                  timestamp_group_ordinal,
                  roll_result,
                  result_type,
-                 reward_type,
                  reward_id,
-                 reward_name,
-                 reward_rank,
-                 star_rank,
                  quantity
-               ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-               ON CONFLICT (uid, record_uid) DO UPDATE SET
-                 reward_type = EXCLUDED.reward_type,
-                 reward_name = EXCLUDED.reward_name,
-                 reward_rank = EXCLUDED.reward_rank,
-                 star_rank = EXCLUDED.star_rank"#,
+               ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"#,
         )
         .bind(pull.uid)
         .bind(&pull.record_uid)
         .bind(&pull.pool_group_id)
-        .bind(&pull.banner_type)
         .bind(&pull.timestamp_raw)
         .bind(pull.timestamp_group_ordinal)
         .bind(pull.roll_result)
         .bind(&pull.result_type)
-        .bind(&pull.reward_type)
         .bind(&pull.reward_id)
-        .bind(&pull.reward_name)
-        .bind(&pull.reward_rank)
-        .bind(pull.star_rank)
         .bind(pull.quantity)
         .execute(&mut *tx)
         .await?;
@@ -409,6 +435,7 @@ pub async fn import_tracker_pulls(
 
     Ok(Some(TrackerImportResult {
         inserted,
+        updated,
         total: current_total + inserted,
     }))
 }
@@ -499,16 +526,11 @@ mod tests {
             uid,
             record_uid: record_uid.to_string(),
             pool_group_id: "Lottery_LimitedCharacter".to_string(),
-            banner_type: "limited-character".to_string(),
             timestamp_raw: "2026-06-07 19:28:21".to_string(),
             timestamp_group_ordinal: Some(0),
             roll_result: Some(1),
             result_type: Some("single".to_string()),
-            reward_type: "character".to_string(),
             reward_id: "test_reward".to_string(),
-            reward_name: "Test Reward".to_string(),
-            reward_rank: Some("S".to_string()),
-            star_rank: Some(5),
             quantity: Some(1),
             imported_at: Utc::now(),
         }
@@ -679,7 +701,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn reimport_updates_only_derived_reward_fields_for_existing_pull() {
+    async fn reimport_updates_only_safe_repair_fields_for_duplicate_pull() {
         let pool = test_pool().await;
         let (username, user_id) = create_test_user(&pool).await;
         let uid = next_uid();
@@ -690,31 +712,26 @@ mod tests {
             .expect("claim should be created");
 
         let mut original_pull = sample_pull(uid, "repair-1");
-        original_pull.reward_type = "unknown".to_string();
         original_pull.reward_id = "1076".to_string();
-        original_pull.reward_name = "1076".to_string();
-        original_pull.reward_rank = None;
-        original_pull.star_rank = None;
         import_tracker_pulls(uid, std::slice::from_ref(&original_pull), 10, &pool)
             .await
             .expect("initial import should succeed")
             .expect("initial import should not hit the limit");
 
         let mut repaired_pull = original_pull.clone();
-        repaired_pull.reward_type = "character".to_string();
-        repaired_pull.reward_name = "Shinku".to_string();
-        repaired_pull.reward_rank = Some("S".to_string());
-        repaired_pull.star_rank = Some(5);
+        repaired_pull.reward_id = "1076_changed".to_string();
         repaired_pull.timestamp_raw = "2030-01-01 00:00:00".to_string();
         repaired_pull.timestamp_group_ordinal = Some(99);
         repaired_pull.roll_result = Some(99);
         repaired_pull.result_type = Some("dice".to_string());
         repaired_pull.quantity = Some(9);
 
-        import_tracker_pulls(uid, &[repaired_pull], 10, &pool)
+        let result = import_tracker_pulls(uid, &[repaired_pull], 10, &pool)
             .await
             .expect("repair import should succeed")
             .expect("repair import should not hit the limit");
+        assert_eq!(result.inserted, 0);
+        assert_eq!(result.updated, 1);
 
         let pulls = tracker_pulls_for_uid(uid, &pool)
             .await
@@ -724,19 +741,49 @@ mod tests {
             .find(|pull| pull.record_uid == "repair-1")
             .expect("repaired pull should exist");
 
-        assert_eq!(stored.reward_type, "character");
         assert_eq!(stored.reward_id, "1076");
-        assert_eq!(stored.reward_name, "Shinku");
-        assert_eq!(stored.reward_rank, Some("S".to_string()));
-        assert_eq!(stored.star_rank, Some(5));
         assert_eq!(stored.timestamp_raw, original_pull.timestamp_raw);
         assert_eq!(
             stored.timestamp_group_ordinal,
             original_pull.timestamp_group_ordinal
         );
-        assert_eq!(stored.roll_result, original_pull.roll_result);
-        assert_eq!(stored.result_type, original_pull.result_type);
-        assert_eq!(stored.quantity, original_pull.quantity);
+        assert_eq!(stored.roll_result, Some(99));
+        assert_eq!(stored.result_type, Some("dice".to_string()));
+        assert_eq!(stored.quantity, Some(9));
+
+        delete_test_user(&username, &pool).await;
+    }
+
+    #[actix_web::test]
+    async fn reimporting_identical_pull_reports_no_insert_or_update() {
+        let pool = test_pool().await;
+        let (username, user_id) = create_test_user(&pool).await;
+        let uid = next_uid();
+
+        claim_tracker_uid(user_id, uid, 3, &pool)
+            .await
+            .expect("claim should succeed")
+            .expect("claim should be created");
+
+        let pull = sample_pull(uid, "identical-1");
+        import_tracker_pulls(uid, std::slice::from_ref(&pull), 10, &pool)
+            .await
+            .expect("initial import should succeed")
+            .expect("initial import should not hit the limit");
+
+        let result = import_tracker_pulls(uid, &[pull], 10, &pool)
+            .await
+            .expect("duplicate import should succeed")
+            .expect("duplicate import should not hit the limit");
+
+        assert_eq!(result.inserted, 0);
+        assert_eq!(result.updated, 0);
+        assert_eq!(
+            tracker_pull_count(uid, &pool)
+                .await
+                .expect("pull count should load"),
+            1
+        );
 
         delete_test_user(&username, &pool).await;
     }


### PR DESCRIPTION
Remove redundant tracker banner/reward fields from backend storage and let the frontend derive display metadata from pool_group_id and reward_id.

Reimports now repair only safe non-identity fields while preserving pull identity, and the API reports imported and updated roll counts separately.